### PR TITLE
Add BGA rule for BGA Pad to Trace Clearance

### DIFF
--- a/JLCPCB/JLCPCB.kicad_dru
+++ b/JLCPCB/JLCPCB.kicad_dru
@@ -149,6 +149,11 @@
 	(constraint clearance (min 0.2mm))
 )
 
+(rule "JLCPCB: BGA to Trace"
+	(condition "A.Type == 'Pad' && A.Pad_Type == 'SMD' && B.Type == 'Track' &&  A.Net != B.Net")
+	(constraint clearance (min 0.1mm))
+)
+
 
 # --- Minimum Trace Width and Spacing ---
 


### PR DESCRIPTION
Adds a new rule to support JLCPCB's BGA spacing as per:
[https://jlcpcb.com/help/article/BGA-Design-Guidelines---PCB-Layout-Recommendations-for-BGA-packages](https://jlcpcb.com/help/article/BGA-Design-Guidelines---PCB-Layout-Recommendations-for-BGA-packages)