### PR TITLE
#20 Add JLCPCB BGA to Trace clearance rule (net-class scoped)

### DIFF
--- a/JLCPCB/JLCPCB.kicad_dru
+++ b/JLCPCB/JLCPCB.kicad_dru
@@ -149,6 +149,15 @@
 	(constraint clearance (min 0.2mm))
 )
 
+# JLCPCB: "The minimum trace width & spacing under a BGA is 0.1mm(4mil)."
+# https://jlcpcb.com/help/article/BGA-Design-Guidelines---PCB-Layout-Recommendations-for-BGA-packages
+# Scoped to a "BGA" net class so only the BGA fan-out nets get the relaxed
+# clearance. Assign the relevant nets to a BGA net class in Board Setup > Net Classes.
+(rule "JLCPCB: BGA to Trace"
+	(condition "A.NetClass == 'BGA' && B.Type == 'Track' && A.Net != B.Net")
+	(constraint clearance (min 0.1mm))
+)
+
 
 # --- Minimum Trace Width and Spacing ---
 


### PR DESCRIPTION
Reworks #20 by @SolvedSphinx126 with the net-class scoping suggested in review.

## Why not merge #20 directly

The original rule keyed on `A.Pad_Type == 'SMD'`, which matches **every** SMD pad on the board. As written it relaxes pad-to-track clearance to 0.1mm everywhere, not just under a BGA.

## What this does instead

```
(rule "JLCPCB: BGA to Trace"
	(condition "A.NetClass == 'BGA' && B.Type == 'Track' && A.Net != B.Net")
	(constraint clearance (min 0.1mm))
)
```

- Scoped to a `BGA` net class, so only the BGA fan-out nets get the relaxed clearance — nothing else on the board changes. Users assign the relevant nets to a `BGA` net class in **Board Setup > Net Classes**.
- The 0.1mm value is pinned to its source in a comment above the rule (JLCPCB BGA design guidelines) so it's checkable against future capability updates.
- Placed in the Minimum Clearance section, right after `Pad to Trace`.

Credit to @SolvedSphinx126 for the original rule and source. Closes #20.

---
_Generated by [Claude Code](https://claude.ai/code/session_018nCM3QGQaHyfzBwAJz91fs)_