### PR TITLE
Generate design-rule matrix from per-fab TOML source of truth

### DIFF
--- a/.github/workflows/drc.yml
+++ b/.github/workflows/drc.yml
@@ -1,0 +1,83 @@
+name: DRC
+
+# Runs KiCad's electrical Design Rule Check against each fab's test board with
+# its generated .kicad_dru, and publishes the report.
+#
+# INFORMATIONAL, not a gate: the test boards intentionally contain footprints
+# that pass and fail each rule, so violations are expected. The job does not use
+# --exit-code-violations, so it stays green; read the uploaded report / job
+# summary to see what fired. (Syntax of the rule files is gated separately by
+# lint.yml.)
+
+on:
+  workflow_dispatch: {}
+  pull_request:
+    paths:
+      - "**/*.kicad_dru"
+      - "**/*.kicad_pcb"
+      - ".github/workflows/drc.yml"
+
+jobs:
+  drc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install KiCad (kicad-cli)
+        run: |
+          sudo add-apt-repository --yes ppa:kicad/kicad-8.0-releases
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends kicad
+          kicad-cli version
+
+      - name: Run DRC on each fab's default board
+        run: |
+          set -u
+          for board in JLCPCB/JLCPCB.kicad_pcb PCBWay/PCBWay.kicad_pcb; do
+            if [ ! -s "$board" ]; then
+              echo "skip $board (missing or empty)"
+              continue
+            fi
+            echo "== DRC $board =="
+            # No --exit-code-violations: expected violations must not fail the job.
+            kicad-cli pcb drc \
+              --format json \
+              --output "${board%.kicad_pcb}.drc.json" \
+              --severity-error --severity-warning \
+              "$board"
+          done
+
+      - name: Summarise reports
+        if: always()
+        run: |
+          python3 - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import glob, json, os
+          print("# DRC report\n")
+          found = False
+          for f in sorted(glob.glob("**/*.drc.json", recursive=True)):
+              found = True
+              try:
+                  data = json.load(open(f))
+              except Exception as e:
+                  print(f"- `{f}`: could not parse ({e})")
+                  continue
+              v = data.get("violations", [])
+              print(f"## `{f}` — {len(v)} violation(s)\n")
+              for item in v[:50]:
+                  sev = item.get("severity", "?")
+                  desc = item.get("description", "")
+                  print(f"- **{sev}** {desc}")
+              if len(v) > 50:
+                  print(f"- … and {len(v) - 50} more")
+              print()
+          if not found:
+              print("_No DRC reports were produced._")
+          PY
+
+      - name: Upload DRC reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: drc-reports
+          path: "**/*.drc.json"
+          if-no-files-found: ignore

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,12 +4,14 @@ on:
   push:
     paths:
       - "**/*.kicad_dru"
-      - "tools/lint_dru.py"
+      - "capabilities/**"
+      - "tools/**"
       - ".github/workflows/lint.yml"
   pull_request:
     paths:
       - "**/*.kicad_dru"
-      - "tools/lint_dru.py"
+      - "capabilities/**"
+      - "tools/**"
       - ".github/workflows/lint.yml"
 
 jobs:
@@ -19,6 +21,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: "3.11"
+      - name: Check generated files are in sync with capabilities/*.toml
+        run: python3 tools/generate_dru.py --check
       - name: Lint .kicad_dru files
         run: python3 tools/lint_dru.py

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,6 +22,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+      - name: Test the tooling
+        run: python3 tools/test_tools.py
       - name: Check generated files are in sync with capabilities/*.toml
         run: python3 tools/generate_dru.py --check
       - name: Check COMPARISON.md is in sync with capabilities/*.toml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,5 +24,7 @@ jobs:
           python-version: "3.11"
       - name: Check generated files are in sync with capabilities/*.toml
         run: python3 tools/generate_dru.py --check
+      - name: Check COMPARISON.md is in sync with capabilities/*.toml
+        run: python3 tools/gen_comparison.py --check
       - name: Lint .kicad_dru files
         run: python3 tools/lint_dru.py

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ tmp/
 
 # MacOS stuff
 .DS_Store
+
+# Python bytecode cache (from tools/*.py)
+__pycache__/
+*.pyc

--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -1,0 +1,79 @@
+# Fab capability comparison
+
+<!-- GENERATED FILE — do not edit by hand. -->
+<!-- Run tools/gen_comparison.py after editing capabilities/*.toml. -->
+
+Side-by-side of the design-rule values each fab enforces, read from `capabilities/*.toml`. All values in mm unless noted.
+
+## Fixed limits
+
+Shown at each fab's default variant **JLCPCB**: `4L-1oz`, **PCBWay**: `4L-1oz`.
+
+| Parameter | JLCPCB | PCBWay |
+|---|---|---|
+| Drill hole — max | 6.3mm | 6.3mm |
+| Via annular ring — min | 0.075mm | 0.15mm |
+| PTH hole — min | 0.2mm | 0.2mm |
+| PTH hole — max | 6.3mm | 6.35mm |
+| NPTH hole — min | 0.5mm | 0.5mm |
+| Castellated hole — min | 0.6mm | 0.6mm |
+| PTH annular ring — min | 0.075mm | 0.15mm |
+| NPTH annular ring — min | 0.25mm | 0.25mm |
+| Plated slot width — min | 0.5mm | 0.5mm |
+| Non-plated slot width — min | 1.0mm | 0.8mm |
+| Hole-to-hole, different nets | 0.5mm | 0.5mm |
+| Via hole-to-hole, same net | 0.254mm | 0.254mm |
+| Pad-to-pad (no hole), different nets | 0.127mm | 0.127mm |
+| Pad hole-to-hole (with hole), different nets | 0.5mm | 0.5mm |
+| Via hole to trace | 0.254mm | 0.254mm |
+| PTH hole to trace | 0.33mm | 0.33mm |
+| NPTH hole to trace | 0.254mm | 0.254mm |
+| NPTH to copper (non-track) | 0.2mm | 0.20mm |
+| Pad to trace | 0.2mm | 0.2mm |
+| BGA to trace | 0.1mm | — |
+| Silk line width — min | 0.15mm | 0.15mm |
+| Silk text height — min | 1mm | 0.8mm |
+| Pad to silkscreen | 0.15mm | 0.15mm |
+| Trace to board edge (routed) | 0.3mm | 0.3mm |
+
+## By build variant
+
+### JLCPCB
+
+| Variant | Drill hole — min | Via hole — min | Trace width (outer) | Trace spacing (outer) | Trace width (inner) | Trace spacing (inner) |
+|---|---|---|---|---|---|---|
+| `2L-1oz` | 0.3mm | 0.3mm | 0.127mm | 0.127mm | — | — |
+| `4L-1oz` (default) | 0.2mm | 0.2mm | 0.09mm | 0.09mm | 0.09mm | 0.09mm |
+| `4L-2oz` | 0.2mm | 0.2mm | 0.2mm | 0.2mm | 0.2mm | 0.2mm |
+| `6L-1oz` | 0.2mm | 0.2mm | 0.09mm | 0.09mm | 0.09mm | 0.09mm |
+
+### PCBWay
+
+| Variant | Drill hole — min | Via hole — min | Trace width (outer) | Trace spacing (outer) | Trace width (inner) | Trace spacing (inner) |
+|---|---|---|---|---|---|---|
+| `2L-1oz` | 0.15mm | 0.3mm | 0.127mm | 0.127mm | — | — |
+| `4L-1oz` (default) | 0.15mm | 0.2mm | 0.09mm | 0.09mm | 0.1mm | 0.1mm |
+| `4L-2oz` | 0.15mm | 0.2mm | 0.1524mm | 0.1778mm | 0.1524mm | 0.1778mm |
+| `6L-1oz` | 0.15mm | 0.2mm | 0.09mm | 0.09mm | 0.1mm | 0.1mm |
+
+## Impedance-controlled net classes
+
+> Typical starting values for each fab's default stackup — **verify against the fab's impedance calculator for your actual stackup.**
+
+| Net class | JLCPCB (width / gap) | PCBWay (width / gap) |
+|---|---|---|
+| `50R` | 0.2mm / n/a | 0.2mm / n/a |
+| `60R_Diff` | 0.3mm / 0.15mm | 0.3mm / 0.15mm |
+| `90R_Diff` | 0.2mm / 0.13mm | 0.2mm / 0.13mm |
+| `100R_Diff` | 0.2mm / 0.2mm | 0.2mm / 0.2mm |
+| `120R_Diff` | 0.15mm / 0.2mm | 0.15mm / 0.2mm |
+
+## Process notes
+
+|  | JLCPCB | PCBWay |
+|---|---|---|
+| Avoids JLCPCB 4-wire Kelvin test | yes | no |
+| Blind/buried vias allowed | no | yes |
+| Ships a BGA fan-out rule | yes | no |
+| Ships implied catch-all clearances | yes | no |
+

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,146 @@
+# Design: generated design-rule matrix
+
+Status: **accepted** · Tracking branch: `claude/dru-generator-overhaul`
+
+This document describes the overhaul from hand-maintained `.kicad_dru` files to a
+set of files **generated** from a single sourced source-of-truth per fab.
+
+## Why
+
+The rule files are currently hand-edited. That has three problems:
+
+1. **Drift.** JLCPCB and PCBWay files diverged; bugs (lowercase `'track'`,
+   missing net tests, un-implemented TODO rules) sat unnoticed for months.
+2. **The "Choose between" footgun.** Each file ships variants commented out and
+   asks the user to uncomment the right one. Uncomment two and the rules
+   silently fight; uncomment none and a rule is missing. None of it is
+   DRC-validated because "which variant?" is undefined.
+3. **Un-auditable values.** Every numeric limit is buried in an s-expression
+   with no machine-readable link to the fab capability it came from.
+
+Generation fixes all three: one reviewable data file per fab holds every value
+with its source URL; concrete per-variant files are emitted with no editing
+required; and every emitted file is independently lintable and DRC-testable.
+
+## Architecture
+
+```
+capabilities/<FAB>.toml     # source of truth: values + source URLs, base + variants + diff pairs
+tools/generate_dru.py       # reads TOML, emits concrete .kicad_dru files
+tools/lint_dru.py           # existing linter, runs over the generated output
+<FAB>/<FAB>-<variant>.kicad_dru   # GENERATED, committed
+```
+
+- **No separate template language.** Rule *structure* (names, conditions,
+  order, source comments) lives in `generate_dru.py`; rule *values* live in the
+  TOML. This keeps conditionals (inner-layer rules only when there are inner
+  layers, diff-pair blocks, feature flags) in plain Python instead of inventing
+  a mini template engine.
+- **Dependency-free.** TOML is read with the stdlib `tomllib` (Python 3.11+);
+  no Jinja, no PyYAML.
+- **Generated files are committed.** Users (and KiCad) consume files directly
+  from the repo; CI regenerates and asserts `git diff` is empty so the committed
+  output can never drift from the source.
+
+## Source-of-truth schema (per fab)
+
+```toml
+[fab]
+name = "JLCPCB"
+prefix = "JLCPCB"                 # rule-name prefix, e.g. "JLCPCB: "
+capabilities_url = "https://jlcpcb.com/capabilities/pcb-capabilities"
+
+[fab.flags]
+avoid_kelvin_test = true          # emit the JLCPCB-specific Kelvin rule
+allow_blind_buried = false        # emit the "only through-hole vias" assertion
+
+# Values constant across every variant of this fab. Each may carry a `src`.
+[constants]
+drill_hole_min   = { v = "0.2mm", src = "…" }
+drill_hole_max   = { v = "6.3mm" }
+# … all non-varying limits …
+
+# One block per generated file. `over` overrides constants for value-varying rules.
+[[variant]]
+id = "4L-1oz"
+layers = 4
+copper = "1oz"
+label = "4-layer, 1oz outer"
+[variant.over]
+trace_width_outer  = { v = "0.09mm" }
+trace_spacing_outer= { v = "0.09mm" }
+trace_width_inner  = { v = "0.09mm" }
+via_hole           = { v = "0.2mm" }
+
+# Impedance-controlled net classes, baked into every generated file (see caveat).
+[[diffpair]]
+netclass = "100R_Diff"
+track_width = "0.2mm"
+gap = "0.2mm"
+```
+
+Every value is a `{ v, src }` object so the source URL travels with the number
+and the eventual capability audit is a diff on one file.
+
+## The matrix (initial scope: focused, ~4–6 per fab)
+
+Only the combinations the fabs actually promote, standard tier:
+
+| id        | layers | copper |
+|-----------|--------|--------|
+| `2L-1oz`  | 1–2    | 1oz    |
+| `4L-1oz`  | 4      | 1oz    |
+| `4L-2oz`  | 4      | 2oz    |
+| `6L-1oz`  | 6      | 1oz    |
+
+Widening later is data-only — add a `[[variant]]` block. 2-layer variants emit
+no inner-layer trace rules.
+
+## Impedance-controlled net classes
+
+Baked into **every** generated file (inert until a user assigns nets to the
+class, so they add no matrix dimension). Net-class names as requested plus a
+single-ended default:
+
+- `50R` (single-ended)
+- `60R_Diff`, `90R_Diff`, `100R_Diff`, `120R_Diff`
+
+Each emits `track_width` + `diff_pair_gap` scoped by `A.NetClass`.
+
+> **Caveat — read this.** Trace width/gap for a target impedance is a function
+> of the **stackup** (dielectric height, Dk, copper weight), not a fab-wide
+> constant. The values shipped here are **typical starting points for the fab's
+> default stackup** and are flagged in-file as such. Users must verify against
+> the fab's controlled-impedance stackup table / impedance calculator for their
+> actual order. Values will be refined from those tables when they can be
+> sourced (the fab sites are currently egress-blocked from CI).
+
+## Legacy files
+
+**Fully replaced.** The hand-edited `JLCPCB/JLCPCB.kicad_dru` and
+`PCBWay/PCBWay.kicad_dru` are removed; the generated files are the only
+deliverable. Each fab keeps a plainly-named recommended file (an alias of the
+most common variant) so existing copy-paste instructions keep working.
+
+## Validation / CI
+
+1. `tools/lint_dru.py` over all generated files (already in CI).
+2. **Regeneration in-sync check:** run the generator, fail if `git diff` is
+   non-empty — proves committed output matches the source.
+3. (Later) optional `kicad-cli pcb drc` against a paired test board.
+
+## Delivery plan
+
+1. **This branch, foundation PR:** DESIGN.md + TOML for both fabs (values seeded
+   from today's committed rules) + generator + generated matrix (incl. diff-pair
+   classes) + CI in-sync check + README rewrite. Output is behaviour-equivalent
+   to today's rules for the standard variant.
+2. Refine diff-pair and per-variant values from sourced capability tables once
+   reachable.
+3. Optional `kicad-cli` DRC golden tests; tag a release.
+
+## Non-goals (for now)
+
+- Fetching live fab capability values in CI (egress-blocked).
+- Populating the PCBWay test board (issue #16).
+- Adding new fabs — the schema supports it; growth is a follow-up.

--- a/JLCPCB/JLCPCB-2L-1oz.kicad_dru
+++ b/JLCPCB/JLCPCB-2L-1oz.kicad_dru
@@ -3,6 +3,9 @@
 #
 # Matching JLCPCB capabilities: https://jlcpcb.com/capabilities/pcb-capabilities
 #
+# This is the '2L-1oz' variant. If your order differs, use one of
+# the other variants (4L-1oz, 4L-2oz, 6L-1oz) — see the README table.
+#
 # GENERATED FILE — do not edit by hand.
 # Edit capabilities/JLCPCB.toml and run tools/generate_dru.py instead.
 #

--- a/JLCPCB/JLCPCB-2L-1oz.kicad_dru
+++ b/JLCPCB/JLCPCB-2L-1oz.kicad_dru
@@ -1,142 +1,162 @@
 (version 1)
-# Custom Design Rules (DRC) for KiCad — PCBWay: 4 layer, 1oz outer / 0.5oz inner
+# Custom Design Rules (DRC) for KiCad — JLCPCB: 1-2 layer, 1oz copper
 #
-# Matching PCBWay capabilities: https://www.pcbway.com/capabilities.html
+# Matching JLCPCB capabilities: https://jlcpcb.com/capabilities/pcb-capabilities
 #
 # GENERATED FILE — do not edit by hand.
-# Edit capabilities/PCBWay.toml and run tools/generate_dru.py instead.
+# Edit capabilities/JLCPCB.toml and run tools/generate_dru.py instead.
 #
 # KiCad documentation: https://docs.kicad.org/8.0/en/pcbnew/pcbnew.html#custom-design-rules
 
 
 # --- Drill/Hole Size ---
 
-(rule "PCBWay: Drill Hole Size"
-	(constraint hole_size (min 0.15mm) (max 6.3mm))
+(rule "JLCPCB: Drill Hole Size"
+	(constraint hole_size (min 0.3mm) (max 6.3mm))
 )
 
-(rule "PCBWay: Via Hole Size"
+(rule "JLCPCB: Via Hole Size"
 	(condition "A.Type == 'Via'")
-	(constraint hole_size (min 0.2mm))
+	(constraint hole_size (min 0.3mm))
 )
 
-(rule "PCBWay: Via Annular Ring"
+(rule "JLCPCB: Via Annular Ring"
 	(condition "A.Type == 'Via'")
-	(constraint annular_width (min 0.15mm))
+	(constraint annular_width (min 0.075mm))
 )
 
-(rule "PCBWay: PTH Hole Size"
+(rule "JLCPCB: PTH Hole Size"
 	(condition "A.Type == 'Pad' && A.Pad_Type == 'Through-hole' && A.isPlated()")
-	(constraint hole_size (min 0.2mm) (max 6.35mm))
+	(constraint hole_size (min 0.2mm) (max 6.3mm))
 )
 
-(rule "PCBWay: NPTH Hole Size"
+(rule "JLCPCB: NPTH Hole Size"
 	(condition "A.Type == 'Pad' && A.Pad_Type == 'NPTH, mechanical' && !A.isPlated()")
 	(constraint hole_size (min 0.5mm))
 )
 
-(rule "PCBWay: Castellated Hole Size"
+(rule "JLCPCB: Castellated Hole Size"
 	(layer outer)
 	(condition "A.Type == 'Pad' && A.Fabrication_Property == 'Castellated pad'")
 	(constraint hole_size (min 0.6mm))
 )
 
-(rule "PCBWay: PTH Annular Ring"
+(rule "JLCPCB: PTH Annular Ring"
 	(condition "A.Type == 'Pad' && A.Pad_Type == 'Through-hole' && A.isPlated()")
-	(constraint annular_width (min 0.15mm))
+	(constraint annular_width (min 0.075mm))
 )
 
-(rule "PCBWay: NPTH Annular Ring"
+(rule "JLCPCB: NPTH Annular Ring"
 	(condition "A.Type == 'Pad' && A.Pad_Type == 'NPTH, mechanical' && !A.isPlated()")
 	(constraint annular_width (min 0.25mm))
+)
+
+# An expensive 4-Wire Kelvin Test is auto-added for holes < 0.3mm with diameter <= 0.4mm.
+(rule "JLCPCB: Avoid 4-Wire Kelvin Test"
+	(condition "(A.Type == 'Via' && A.Hole < 0.3mm && A.Diameter <= 0.4mm) || (A.Type == 'Pad' && ((A.Hole_Size_X < 0.3mm && A.Size_X <= 0.4mm) || (A.Hole_Size_Y < 0.3mm && A.Size_Y <= 0.4mm)))")
+	(constraint annular_width (min 0.125mm))
+)
+
+
+# --- VIA Support Rules ---
+
+(rule "JLCPCB: Only Throughhole VIAs are supported"
+	(condition "A.Type == 'Via'")
+	(constraint assertion "!(A.isBlindBuriedVia() || A.isMicroVia())")
 )
 
 
 # --- Slot Width ---
 
-(rule "PCBWay: Plated Slot Width"
+(rule "JLCPCB: Plated Slot Width"
 	(condition "A.Type == 'Pad' && (A.Hole_Size_X != A.Hole_Size_Y) && A.isPlated()")
 	(constraint hole_size (min 0.5mm))
 )
 
-(rule "PCBWay: Non-Plated Slot Width"
+(rule "JLCPCB: Non-Plated Slot Width"
 	(condition "A.Type == 'Pad' && (A.Hole_Size_X != A.Hole_Size_Y) && !A.isPlated()")
-	(constraint hole_size (min 0.8mm))
+	(constraint hole_size (min 1.0mm))
 )
 
 
 # --- Minimum Clearance ---
 
-(rule "PCBWay: Hole to Hole Clearance (Different Nets)"
+(rule "JLCPCB: Hole to Hole Clearance (Different Nets)"
 	(condition "A.Net != B.Net")
 	(constraint hole_to_hole (min 0.5mm))
 )
 
-(rule "PCBWay: Via Hole to Via Hole Clearance (Same Net)"
+(rule "JLCPCB: Via Hole to Via Hole Clearance (Same Net)"
 	(condition "A.Type == 'Via' && B.Type == 'Via' && A.Net == B.Net")
 	(constraint hole_to_hole (min 0.254mm))
 )
 
-(rule "PCBWay: Pad to Pad Clearance (Pad without Hole, Different Nets)"
+(rule "JLCPCB: Pad to Pad Clearance (Pad without Hole, Different Nets)"
 	(condition "A.Type == 'Pad' && (A.Pad_Type != 'Through-hole' && A.Pad_Type != 'NPTH, mechanical') && B.Type == 'Pad' && (B.Pad_Type != 'Through-hole' && B.Pad_Type != 'NPTH, mechanical') && A.Net != B.Net")
 	(constraint clearance (min 0.127mm))
 )
 
-(rule "PCBWay: Pad Hole to Pad Hole Clearance (Pad with Hole, Different Nets)"
+(rule "JLCPCB: Pad Hole to Pad Hole Clearance (Pad with Hole, Different Nets)"
 	(condition "A.Type == 'Pad' && (A.Pad_Type == 'Through-hole' || A.Pad_Type == 'NPTH, mechanical') && B.Type == 'Pad' && (B.Pad_Type == 'Through-hole' || B.Pad_Type == 'NPTH, mechanical') && A.Net != B.Net")
 	(constraint hole_to_hole (min 0.5mm))
 )
 
-(rule "PCBWay: Via to Trace"
+# Not stated specifically, but implied by other rules.
+(rule "JLCPCB: Via/Pad to Via/Pad Clearance (Different Nets)"
+	(condition "(A.Type == 'Pad' || A.Type == 'Via') && (B.Type == 'Pad' || B.Type == 'Via') && A.Net != B.Net")
+	(constraint clearance (min 0.127mm))
+)
+
+# Not stated specifically, but implied by other rules.
+(rule "JLCPCB: Via/Pad Hole to Via/Pad Hole Clearance (Same Net)"
+	(condition "(A.Type == 'Pad' || A.Type == 'Via') && (B.Type == 'Pad' || B.Type == 'Via') && A.Net == B.Net")
+	(constraint hole_to_hole (min 0.254mm))
+)
+
+(rule "JLCPCB: Via to Trace"
 	(condition "A.Type == 'Via' && B.Type == 'Track'")
 	(constraint hole_clearance (min 0.254mm))
 )
 
-(rule "PCBWay: PTH to Trace"
+(rule "JLCPCB: PTH to Trace"
 	(condition "A.Type == 'Pad' && A.Pad_Type == 'Through-hole' && A.isPlated() && B.Type == 'Track'")
 	(constraint hole_clearance (min 0.33mm))
 )
 
-(rule "PCBWay: NPTH to Trace"
+(rule "JLCPCB: NPTH to Trace"
 	(condition "A.Type == 'Pad' && A.Pad_Type == 'NPTH, mechanical' && !A.isPlated() && B.Type == 'Track'")
 	(constraint hole_clearance (min 0.254mm))
 )
 
-(rule "PCBWay: NPTH to Copper (non-Track)"
+(rule "JLCPCB: NPTH to Copper (non-Track)"
 	(condition "A.Type == 'Pad' && A.Pad_Type == 'NPTH, mechanical' && !A.isPlated() && B.Type != 'Track'")
-	(constraint hole_clearance (min 0.20mm))
+	(constraint hole_clearance (min 0.2mm))
 )
 
-(rule "PCBWay: Pad to Trace"
+(rule "JLCPCB: Pad to Trace"
 	(condition "A.Type == 'Pad' && (A.Pad_Type == 'Through-hole' || A.Pad_Type == 'NPTH, mechanical') && B.Type == 'Track' && A.Net != B.Net")
 	(constraint clearance (min 0.2mm))
+)
+
+# BGA fan-out clearance. Assign BGA fan-out nets to a 'BGA' net class.
+(rule "JLCPCB: BGA to Trace"
+	(condition "A.NetClass == 'BGA' && B.Type == 'Track' && A.Net != B.Net")
+	(constraint clearance (min 0.1mm))
 )
 
 
 # --- Minimum Trace Width and Spacing ---
 
-(rule "PCBWay: Trace Width (Outer Layer)"
+(rule "JLCPCB: Trace Width (Outer Layer)"
 	(layer outer)
 	(condition "A.Type == 'Track'")
-	(constraint track_width (min 0.09mm))
+	(constraint track_width (min 0.127mm))
 )
 
-(rule "PCBWay: Trace Spacing (Outer Layer)"
+(rule "JLCPCB: Trace Spacing (Outer Layer)"
 	(layer outer)
 	(condition "A.Type == 'Track' && B.Type == 'Track'")
-	(constraint clearance (min 0.09mm))
-)
-
-(rule "PCBWay: Trace Width (Inner Layer)"
-	(layer inner)
-	(condition "A.Type == 'Track'")
-	(constraint track_width (min 0.1mm))
-)
-
-(rule "PCBWay: Trace Spacing (Inner Layer)"
-	(layer inner)
-	(condition "A.Type == 'Track' && B.Type == 'Track'")
-	(constraint clearance (min 0.1mm))
+	(constraint clearance (min 0.127mm))
 )
 
 
@@ -144,36 +164,36 @@
 #
 # WARNING: trace width/gap for a target impedance depend on YOUR stackup
 # (dielectric height, Dk, copper weight). The values below are typical
-# starting points for PCBWay's default stackup — verify against
-# PCBWay's impedance calculator for your actual order. Constraints use
+# starting points for JLCPCB's default stackup — verify against
+# JLCPCB's impedance calculator for your actual order. Constraints use
 # (opt ...) so they guide the router without raising nuisance DRC errors;
 # tighten to (min/max) once tuned. Assign nets to these classes in
 # Board Setup > Net Classes.
 
-(rule "PCBWay: 50R Single-Ended"
+(rule "JLCPCB: 50R Single-Ended"
 	(condition "A.NetClass == '50R'")
 	(constraint track_width (opt 0.2mm))
 )
 
-(rule "PCBWay: 60R_Diff Differential Pair"
+(rule "JLCPCB: 60R_Diff Differential Pair"
 	(condition "A.NetClass == '60R_Diff'")
 	(constraint track_width (opt 0.3mm))
 	(constraint diff_pair_gap (opt 0.15mm))
 )
 
-(rule "PCBWay: 90R_Diff Differential Pair"
+(rule "JLCPCB: 90R_Diff Differential Pair"
 	(condition "A.NetClass == '90R_Diff'")
 	(constraint track_width (opt 0.2mm))
 	(constraint diff_pair_gap (opt 0.13mm))
 )
 
-(rule "PCBWay: 100R_Diff Differential Pair"
+(rule "JLCPCB: 100R_Diff Differential Pair"
 	(condition "A.NetClass == '100R_Diff'")
 	(constraint track_width (opt 0.2mm))
 	(constraint diff_pair_gap (opt 0.2mm))
 )
 
-(rule "PCBWay: 120R_Diff Differential Pair"
+(rule "JLCPCB: 120R_Diff Differential Pair"
 	(condition "A.NetClass == '120R_Diff'")
 	(constraint track_width (opt 0.15mm))
 	(constraint diff_pair_gap (opt 0.2mm))
@@ -182,19 +202,19 @@
 
 # --- Legend ---
 
-(rule "PCBWay: Minimum Line Width"
+(rule "JLCPCB: Minimum Line Width"
 	(layer "?.Silkscreen")
 	(condition "A.Type == 'Text' || A.Type == 'Text Box'")
 	(constraint text_thickness (min 0.15mm))
 )
 
-(rule "PCBWay: Minimum Text Height"
+(rule "JLCPCB: Minimum Text Height"
 	(layer "?.Silkscreen")
 	(condition "A.Type == 'Text' || A.Type == 'Text Box'")
-	(constraint text_height (min 0.8mm))
+	(constraint text_height (min 1mm))
 )
 
-(rule "PCBWay: Pad to Silkscreen"
+(rule "JLCPCB: Pad to Silkscreen"
 	(condition "A.Type == 'Pad' && ((A.existsOnLayer('F.Mask') && B.Layer == 'F.Silkscreen') || (A.existsOnLayer('B.Mask') && B.Layer == 'B.Silkscreen'))")
 	(constraint silk_clearance (min 0.15mm))
 )
@@ -202,7 +222,7 @@
 
 # --- Board Outlines ---
 
-(rule "PCBWay: Trace to Board Edge"
+(rule "JLCPCB: Trace to Board Edge"
 	(condition "A.Type == 'Track'")
 	(constraint edge_clearance (min 0.3mm))
 )

--- a/JLCPCB/JLCPCB-4L-2oz.kicad_dru
+++ b/JLCPCB/JLCPCB-4L-2oz.kicad_dru
@@ -3,6 +3,9 @@
 #
 # Matching JLCPCB capabilities: https://jlcpcb.com/capabilities/pcb-capabilities
 #
+# This is the '4L-2oz' variant. If your order differs, use one of
+# the other variants (2L-1oz, 4L-1oz, 6L-1oz) — see the README table.
+#
 # GENERATED FILE — do not edit by hand.
 # Edit capabilities/JLCPCB.toml and run tools/generate_dru.py instead.
 #

--- a/JLCPCB/JLCPCB-4L-2oz.kicad_dru
+++ b/JLCPCB/JLCPCB-4L-2oz.kicad_dru
@@ -1,142 +1,174 @@
 (version 1)
-# Custom Design Rules (DRC) for KiCad — PCBWay: 4 layer, 1oz outer / 0.5oz inner
+# Custom Design Rules (DRC) for KiCad — JLCPCB: 4 layer, 2oz copper
 #
-# Matching PCBWay capabilities: https://www.pcbway.com/capabilities.html
+# Matching JLCPCB capabilities: https://jlcpcb.com/capabilities/pcb-capabilities
 #
 # GENERATED FILE — do not edit by hand.
-# Edit capabilities/PCBWay.toml and run tools/generate_dru.py instead.
+# Edit capabilities/JLCPCB.toml and run tools/generate_dru.py instead.
 #
 # KiCad documentation: https://docs.kicad.org/8.0/en/pcbnew/pcbnew.html#custom-design-rules
 
 
 # --- Drill/Hole Size ---
 
-(rule "PCBWay: Drill Hole Size"
-	(constraint hole_size (min 0.15mm) (max 6.3mm))
+(rule "JLCPCB: Drill Hole Size"
+	(constraint hole_size (min 0.2mm) (max 6.3mm))
 )
 
-(rule "PCBWay: Via Hole Size"
+(rule "JLCPCB: Via Hole Size"
 	(condition "A.Type == 'Via'")
 	(constraint hole_size (min 0.2mm))
 )
 
-(rule "PCBWay: Via Annular Ring"
+(rule "JLCPCB: Via Annular Ring"
 	(condition "A.Type == 'Via'")
-	(constraint annular_width (min 0.15mm))
+	(constraint annular_width (min 0.075mm))
 )
 
-(rule "PCBWay: PTH Hole Size"
+(rule "JLCPCB: PTH Hole Size"
 	(condition "A.Type == 'Pad' && A.Pad_Type == 'Through-hole' && A.isPlated()")
-	(constraint hole_size (min 0.2mm) (max 6.35mm))
+	(constraint hole_size (min 0.2mm) (max 6.3mm))
 )
 
-(rule "PCBWay: NPTH Hole Size"
+(rule "JLCPCB: NPTH Hole Size"
 	(condition "A.Type == 'Pad' && A.Pad_Type == 'NPTH, mechanical' && !A.isPlated()")
 	(constraint hole_size (min 0.5mm))
 )
 
-(rule "PCBWay: Castellated Hole Size"
+(rule "JLCPCB: Castellated Hole Size"
 	(layer outer)
 	(condition "A.Type == 'Pad' && A.Fabrication_Property == 'Castellated pad'")
 	(constraint hole_size (min 0.6mm))
 )
 
-(rule "PCBWay: PTH Annular Ring"
+(rule "JLCPCB: PTH Annular Ring"
 	(condition "A.Type == 'Pad' && A.Pad_Type == 'Through-hole' && A.isPlated()")
-	(constraint annular_width (min 0.15mm))
+	(constraint annular_width (min 0.075mm))
 )
 
-(rule "PCBWay: NPTH Annular Ring"
+(rule "JLCPCB: NPTH Annular Ring"
 	(condition "A.Type == 'Pad' && A.Pad_Type == 'NPTH, mechanical' && !A.isPlated()")
 	(constraint annular_width (min 0.25mm))
+)
+
+# An expensive 4-Wire Kelvin Test is auto-added for holes < 0.3mm with diameter <= 0.4mm.
+(rule "JLCPCB: Avoid 4-Wire Kelvin Test"
+	(condition "(A.Type == 'Via' && A.Hole < 0.3mm && A.Diameter <= 0.4mm) || (A.Type == 'Pad' && ((A.Hole_Size_X < 0.3mm && A.Size_X <= 0.4mm) || (A.Hole_Size_Y < 0.3mm && A.Size_Y <= 0.4mm)))")
+	(constraint annular_width (min 0.125mm))
+)
+
+
+# --- VIA Support Rules ---
+
+(rule "JLCPCB: Only Throughhole VIAs are supported"
+	(condition "A.Type == 'Via'")
+	(constraint assertion "!(A.isBlindBuriedVia() || A.isMicroVia())")
 )
 
 
 # --- Slot Width ---
 
-(rule "PCBWay: Plated Slot Width"
+(rule "JLCPCB: Plated Slot Width"
 	(condition "A.Type == 'Pad' && (A.Hole_Size_X != A.Hole_Size_Y) && A.isPlated()")
 	(constraint hole_size (min 0.5mm))
 )
 
-(rule "PCBWay: Non-Plated Slot Width"
+(rule "JLCPCB: Non-Plated Slot Width"
 	(condition "A.Type == 'Pad' && (A.Hole_Size_X != A.Hole_Size_Y) && !A.isPlated()")
-	(constraint hole_size (min 0.8mm))
+	(constraint hole_size (min 1.0mm))
 )
 
 
 # --- Minimum Clearance ---
 
-(rule "PCBWay: Hole to Hole Clearance (Different Nets)"
+(rule "JLCPCB: Hole to Hole Clearance (Different Nets)"
 	(condition "A.Net != B.Net")
 	(constraint hole_to_hole (min 0.5mm))
 )
 
-(rule "PCBWay: Via Hole to Via Hole Clearance (Same Net)"
+(rule "JLCPCB: Via Hole to Via Hole Clearance (Same Net)"
 	(condition "A.Type == 'Via' && B.Type == 'Via' && A.Net == B.Net")
 	(constraint hole_to_hole (min 0.254mm))
 )
 
-(rule "PCBWay: Pad to Pad Clearance (Pad without Hole, Different Nets)"
+(rule "JLCPCB: Pad to Pad Clearance (Pad without Hole, Different Nets)"
 	(condition "A.Type == 'Pad' && (A.Pad_Type != 'Through-hole' && A.Pad_Type != 'NPTH, mechanical') && B.Type == 'Pad' && (B.Pad_Type != 'Through-hole' && B.Pad_Type != 'NPTH, mechanical') && A.Net != B.Net")
 	(constraint clearance (min 0.127mm))
 )
 
-(rule "PCBWay: Pad Hole to Pad Hole Clearance (Pad with Hole, Different Nets)"
+(rule "JLCPCB: Pad Hole to Pad Hole Clearance (Pad with Hole, Different Nets)"
 	(condition "A.Type == 'Pad' && (A.Pad_Type == 'Through-hole' || A.Pad_Type == 'NPTH, mechanical') && B.Type == 'Pad' && (B.Pad_Type == 'Through-hole' || B.Pad_Type == 'NPTH, mechanical') && A.Net != B.Net")
 	(constraint hole_to_hole (min 0.5mm))
 )
 
-(rule "PCBWay: Via to Trace"
+# Not stated specifically, but implied by other rules.
+(rule "JLCPCB: Via/Pad to Via/Pad Clearance (Different Nets)"
+	(condition "(A.Type == 'Pad' || A.Type == 'Via') && (B.Type == 'Pad' || B.Type == 'Via') && A.Net != B.Net")
+	(constraint clearance (min 0.127mm))
+)
+
+# Not stated specifically, but implied by other rules.
+(rule "JLCPCB: Via/Pad Hole to Via/Pad Hole Clearance (Same Net)"
+	(condition "(A.Type == 'Pad' || A.Type == 'Via') && (B.Type == 'Pad' || B.Type == 'Via') && A.Net == B.Net")
+	(constraint hole_to_hole (min 0.254mm))
+)
+
+(rule "JLCPCB: Via to Trace"
 	(condition "A.Type == 'Via' && B.Type == 'Track'")
 	(constraint hole_clearance (min 0.254mm))
 )
 
-(rule "PCBWay: PTH to Trace"
+(rule "JLCPCB: PTH to Trace"
 	(condition "A.Type == 'Pad' && A.Pad_Type == 'Through-hole' && A.isPlated() && B.Type == 'Track'")
 	(constraint hole_clearance (min 0.33mm))
 )
 
-(rule "PCBWay: NPTH to Trace"
+(rule "JLCPCB: NPTH to Trace"
 	(condition "A.Type == 'Pad' && A.Pad_Type == 'NPTH, mechanical' && !A.isPlated() && B.Type == 'Track'")
 	(constraint hole_clearance (min 0.254mm))
 )
 
-(rule "PCBWay: NPTH to Copper (non-Track)"
+(rule "JLCPCB: NPTH to Copper (non-Track)"
 	(condition "A.Type == 'Pad' && A.Pad_Type == 'NPTH, mechanical' && !A.isPlated() && B.Type != 'Track'")
-	(constraint hole_clearance (min 0.20mm))
+	(constraint hole_clearance (min 0.2mm))
 )
 
-(rule "PCBWay: Pad to Trace"
+(rule "JLCPCB: Pad to Trace"
 	(condition "A.Type == 'Pad' && (A.Pad_Type == 'Through-hole' || A.Pad_Type == 'NPTH, mechanical') && B.Type == 'Track' && A.Net != B.Net")
 	(constraint clearance (min 0.2mm))
+)
+
+# BGA fan-out clearance. Assign BGA fan-out nets to a 'BGA' net class.
+(rule "JLCPCB: BGA to Trace"
+	(condition "A.NetClass == 'BGA' && B.Type == 'Track' && A.Net != B.Net")
+	(constraint clearance (min 0.1mm))
 )
 
 
 # --- Minimum Trace Width and Spacing ---
 
-(rule "PCBWay: Trace Width (Outer Layer)"
+(rule "JLCPCB: Trace Width (Outer Layer)"
 	(layer outer)
 	(condition "A.Type == 'Track'")
-	(constraint track_width (min 0.09mm))
+	(constraint track_width (min 0.2mm))
 )
 
-(rule "PCBWay: Trace Spacing (Outer Layer)"
+(rule "JLCPCB: Trace Spacing (Outer Layer)"
 	(layer outer)
 	(condition "A.Type == 'Track' && B.Type == 'Track'")
-	(constraint clearance (min 0.09mm))
+	(constraint clearance (min 0.2mm))
 )
 
-(rule "PCBWay: Trace Width (Inner Layer)"
+(rule "JLCPCB: Trace Width (Inner Layer)"
 	(layer inner)
 	(condition "A.Type == 'Track'")
-	(constraint track_width (min 0.1mm))
+	(constraint track_width (min 0.2mm))
 )
 
-(rule "PCBWay: Trace Spacing (Inner Layer)"
+(rule "JLCPCB: Trace Spacing (Inner Layer)"
 	(layer inner)
 	(condition "A.Type == 'Track' && B.Type == 'Track'")
-	(constraint clearance (min 0.1mm))
+	(constraint clearance (min 0.2mm))
 )
 
 
@@ -144,36 +176,36 @@
 #
 # WARNING: trace width/gap for a target impedance depend on YOUR stackup
 # (dielectric height, Dk, copper weight). The values below are typical
-# starting points for PCBWay's default stackup — verify against
-# PCBWay's impedance calculator for your actual order. Constraints use
+# starting points for JLCPCB's default stackup — verify against
+# JLCPCB's impedance calculator for your actual order. Constraints use
 # (opt ...) so they guide the router without raising nuisance DRC errors;
 # tighten to (min/max) once tuned. Assign nets to these classes in
 # Board Setup > Net Classes.
 
-(rule "PCBWay: 50R Single-Ended"
+(rule "JLCPCB: 50R Single-Ended"
 	(condition "A.NetClass == '50R'")
 	(constraint track_width (opt 0.2mm))
 )
 
-(rule "PCBWay: 60R_Diff Differential Pair"
+(rule "JLCPCB: 60R_Diff Differential Pair"
 	(condition "A.NetClass == '60R_Diff'")
 	(constraint track_width (opt 0.3mm))
 	(constraint diff_pair_gap (opt 0.15mm))
 )
 
-(rule "PCBWay: 90R_Diff Differential Pair"
+(rule "JLCPCB: 90R_Diff Differential Pair"
 	(condition "A.NetClass == '90R_Diff'")
 	(constraint track_width (opt 0.2mm))
 	(constraint diff_pair_gap (opt 0.13mm))
 )
 
-(rule "PCBWay: 100R_Diff Differential Pair"
+(rule "JLCPCB: 100R_Diff Differential Pair"
 	(condition "A.NetClass == '100R_Diff'")
 	(constraint track_width (opt 0.2mm))
 	(constraint diff_pair_gap (opt 0.2mm))
 )
 
-(rule "PCBWay: 120R_Diff Differential Pair"
+(rule "JLCPCB: 120R_Diff Differential Pair"
 	(condition "A.NetClass == '120R_Diff'")
 	(constraint track_width (opt 0.15mm))
 	(constraint diff_pair_gap (opt 0.2mm))
@@ -182,19 +214,19 @@
 
 # --- Legend ---
 
-(rule "PCBWay: Minimum Line Width"
+(rule "JLCPCB: Minimum Line Width"
 	(layer "?.Silkscreen")
 	(condition "A.Type == 'Text' || A.Type == 'Text Box'")
 	(constraint text_thickness (min 0.15mm))
 )
 
-(rule "PCBWay: Minimum Text Height"
+(rule "JLCPCB: Minimum Text Height"
 	(layer "?.Silkscreen")
 	(condition "A.Type == 'Text' || A.Type == 'Text Box'")
-	(constraint text_height (min 0.8mm))
+	(constraint text_height (min 1mm))
 )
 
-(rule "PCBWay: Pad to Silkscreen"
+(rule "JLCPCB: Pad to Silkscreen"
 	(condition "A.Type == 'Pad' && ((A.existsOnLayer('F.Mask') && B.Layer == 'F.Silkscreen') || (A.existsOnLayer('B.Mask') && B.Layer == 'B.Silkscreen'))")
 	(constraint silk_clearance (min 0.15mm))
 )
@@ -202,7 +234,7 @@
 
 # --- Board Outlines ---
 
-(rule "PCBWay: Trace to Board Edge"
+(rule "JLCPCB: Trace to Board Edge"
 	(condition "A.Type == 'Track'")
 	(constraint edge_clearance (min 0.3mm))
 )

--- a/JLCPCB/JLCPCB-6L-1oz.kicad_dru
+++ b/JLCPCB/JLCPCB-6L-1oz.kicad_dru
@@ -3,6 +3,9 @@
 #
 # Matching JLCPCB capabilities: https://jlcpcb.com/capabilities/pcb-capabilities
 #
+# This is the '6L-1oz' variant. If your order differs, use one of
+# the other variants (2L-1oz, 4L-1oz, 4L-2oz) — see the README table.
+#
 # GENERATED FILE — do not edit by hand.
 # Edit capabilities/JLCPCB.toml and run tools/generate_dru.py instead.
 #

--- a/JLCPCB/JLCPCB-6L-1oz.kicad_dru
+++ b/JLCPCB/JLCPCB-6L-1oz.kicad_dru
@@ -1,142 +1,174 @@
 (version 1)
-# Custom Design Rules (DRC) for KiCad — PCBWay: 4 layer, 1oz outer / 0.5oz inner
+# Custom Design Rules (DRC) for KiCad — JLCPCB: 6 layer, 1oz outer / 0.5oz inner
 #
-# Matching PCBWay capabilities: https://www.pcbway.com/capabilities.html
+# Matching JLCPCB capabilities: https://jlcpcb.com/capabilities/pcb-capabilities
 #
 # GENERATED FILE — do not edit by hand.
-# Edit capabilities/PCBWay.toml and run tools/generate_dru.py instead.
+# Edit capabilities/JLCPCB.toml and run tools/generate_dru.py instead.
 #
 # KiCad documentation: https://docs.kicad.org/8.0/en/pcbnew/pcbnew.html#custom-design-rules
 
 
 # --- Drill/Hole Size ---
 
-(rule "PCBWay: Drill Hole Size"
-	(constraint hole_size (min 0.15mm) (max 6.3mm))
+(rule "JLCPCB: Drill Hole Size"
+	(constraint hole_size (min 0.2mm) (max 6.3mm))
 )
 
-(rule "PCBWay: Via Hole Size"
+(rule "JLCPCB: Via Hole Size"
 	(condition "A.Type == 'Via'")
 	(constraint hole_size (min 0.2mm))
 )
 
-(rule "PCBWay: Via Annular Ring"
+(rule "JLCPCB: Via Annular Ring"
 	(condition "A.Type == 'Via'")
-	(constraint annular_width (min 0.15mm))
+	(constraint annular_width (min 0.075mm))
 )
 
-(rule "PCBWay: PTH Hole Size"
+(rule "JLCPCB: PTH Hole Size"
 	(condition "A.Type == 'Pad' && A.Pad_Type == 'Through-hole' && A.isPlated()")
-	(constraint hole_size (min 0.2mm) (max 6.35mm))
+	(constraint hole_size (min 0.2mm) (max 6.3mm))
 )
 
-(rule "PCBWay: NPTH Hole Size"
+(rule "JLCPCB: NPTH Hole Size"
 	(condition "A.Type == 'Pad' && A.Pad_Type == 'NPTH, mechanical' && !A.isPlated()")
 	(constraint hole_size (min 0.5mm))
 )
 
-(rule "PCBWay: Castellated Hole Size"
+(rule "JLCPCB: Castellated Hole Size"
 	(layer outer)
 	(condition "A.Type == 'Pad' && A.Fabrication_Property == 'Castellated pad'")
 	(constraint hole_size (min 0.6mm))
 )
 
-(rule "PCBWay: PTH Annular Ring"
+(rule "JLCPCB: PTH Annular Ring"
 	(condition "A.Type == 'Pad' && A.Pad_Type == 'Through-hole' && A.isPlated()")
-	(constraint annular_width (min 0.15mm))
+	(constraint annular_width (min 0.075mm))
 )
 
-(rule "PCBWay: NPTH Annular Ring"
+(rule "JLCPCB: NPTH Annular Ring"
 	(condition "A.Type == 'Pad' && A.Pad_Type == 'NPTH, mechanical' && !A.isPlated()")
 	(constraint annular_width (min 0.25mm))
+)
+
+# An expensive 4-Wire Kelvin Test is auto-added for holes < 0.3mm with diameter <= 0.4mm.
+(rule "JLCPCB: Avoid 4-Wire Kelvin Test"
+	(condition "(A.Type == 'Via' && A.Hole < 0.3mm && A.Diameter <= 0.4mm) || (A.Type == 'Pad' && ((A.Hole_Size_X < 0.3mm && A.Size_X <= 0.4mm) || (A.Hole_Size_Y < 0.3mm && A.Size_Y <= 0.4mm)))")
+	(constraint annular_width (min 0.125mm))
+)
+
+
+# --- VIA Support Rules ---
+
+(rule "JLCPCB: Only Throughhole VIAs are supported"
+	(condition "A.Type == 'Via'")
+	(constraint assertion "!(A.isBlindBuriedVia() || A.isMicroVia())")
 )
 
 
 # --- Slot Width ---
 
-(rule "PCBWay: Plated Slot Width"
+(rule "JLCPCB: Plated Slot Width"
 	(condition "A.Type == 'Pad' && (A.Hole_Size_X != A.Hole_Size_Y) && A.isPlated()")
 	(constraint hole_size (min 0.5mm))
 )
 
-(rule "PCBWay: Non-Plated Slot Width"
+(rule "JLCPCB: Non-Plated Slot Width"
 	(condition "A.Type == 'Pad' && (A.Hole_Size_X != A.Hole_Size_Y) && !A.isPlated()")
-	(constraint hole_size (min 0.8mm))
+	(constraint hole_size (min 1.0mm))
 )
 
 
 # --- Minimum Clearance ---
 
-(rule "PCBWay: Hole to Hole Clearance (Different Nets)"
+(rule "JLCPCB: Hole to Hole Clearance (Different Nets)"
 	(condition "A.Net != B.Net")
 	(constraint hole_to_hole (min 0.5mm))
 )
 
-(rule "PCBWay: Via Hole to Via Hole Clearance (Same Net)"
+(rule "JLCPCB: Via Hole to Via Hole Clearance (Same Net)"
 	(condition "A.Type == 'Via' && B.Type == 'Via' && A.Net == B.Net")
 	(constraint hole_to_hole (min 0.254mm))
 )
 
-(rule "PCBWay: Pad to Pad Clearance (Pad without Hole, Different Nets)"
+(rule "JLCPCB: Pad to Pad Clearance (Pad without Hole, Different Nets)"
 	(condition "A.Type == 'Pad' && (A.Pad_Type != 'Through-hole' && A.Pad_Type != 'NPTH, mechanical') && B.Type == 'Pad' && (B.Pad_Type != 'Through-hole' && B.Pad_Type != 'NPTH, mechanical') && A.Net != B.Net")
 	(constraint clearance (min 0.127mm))
 )
 
-(rule "PCBWay: Pad Hole to Pad Hole Clearance (Pad with Hole, Different Nets)"
+(rule "JLCPCB: Pad Hole to Pad Hole Clearance (Pad with Hole, Different Nets)"
 	(condition "A.Type == 'Pad' && (A.Pad_Type == 'Through-hole' || A.Pad_Type == 'NPTH, mechanical') && B.Type == 'Pad' && (B.Pad_Type == 'Through-hole' || B.Pad_Type == 'NPTH, mechanical') && A.Net != B.Net")
 	(constraint hole_to_hole (min 0.5mm))
 )
 
-(rule "PCBWay: Via to Trace"
+# Not stated specifically, but implied by other rules.
+(rule "JLCPCB: Via/Pad to Via/Pad Clearance (Different Nets)"
+	(condition "(A.Type == 'Pad' || A.Type == 'Via') && (B.Type == 'Pad' || B.Type == 'Via') && A.Net != B.Net")
+	(constraint clearance (min 0.127mm))
+)
+
+# Not stated specifically, but implied by other rules.
+(rule "JLCPCB: Via/Pad Hole to Via/Pad Hole Clearance (Same Net)"
+	(condition "(A.Type == 'Pad' || A.Type == 'Via') && (B.Type == 'Pad' || B.Type == 'Via') && A.Net == B.Net")
+	(constraint hole_to_hole (min 0.254mm))
+)
+
+(rule "JLCPCB: Via to Trace"
 	(condition "A.Type == 'Via' && B.Type == 'Track'")
 	(constraint hole_clearance (min 0.254mm))
 )
 
-(rule "PCBWay: PTH to Trace"
+(rule "JLCPCB: PTH to Trace"
 	(condition "A.Type == 'Pad' && A.Pad_Type == 'Through-hole' && A.isPlated() && B.Type == 'Track'")
 	(constraint hole_clearance (min 0.33mm))
 )
 
-(rule "PCBWay: NPTH to Trace"
+(rule "JLCPCB: NPTH to Trace"
 	(condition "A.Type == 'Pad' && A.Pad_Type == 'NPTH, mechanical' && !A.isPlated() && B.Type == 'Track'")
 	(constraint hole_clearance (min 0.254mm))
 )
 
-(rule "PCBWay: NPTH to Copper (non-Track)"
+(rule "JLCPCB: NPTH to Copper (non-Track)"
 	(condition "A.Type == 'Pad' && A.Pad_Type == 'NPTH, mechanical' && !A.isPlated() && B.Type != 'Track'")
-	(constraint hole_clearance (min 0.20mm))
+	(constraint hole_clearance (min 0.2mm))
 )
 
-(rule "PCBWay: Pad to Trace"
+(rule "JLCPCB: Pad to Trace"
 	(condition "A.Type == 'Pad' && (A.Pad_Type == 'Through-hole' || A.Pad_Type == 'NPTH, mechanical') && B.Type == 'Track' && A.Net != B.Net")
 	(constraint clearance (min 0.2mm))
+)
+
+# BGA fan-out clearance. Assign BGA fan-out nets to a 'BGA' net class.
+(rule "JLCPCB: BGA to Trace"
+	(condition "A.NetClass == 'BGA' && B.Type == 'Track' && A.Net != B.Net")
+	(constraint clearance (min 0.1mm))
 )
 
 
 # --- Minimum Trace Width and Spacing ---
 
-(rule "PCBWay: Trace Width (Outer Layer)"
+(rule "JLCPCB: Trace Width (Outer Layer)"
 	(layer outer)
 	(condition "A.Type == 'Track'")
 	(constraint track_width (min 0.09mm))
 )
 
-(rule "PCBWay: Trace Spacing (Outer Layer)"
+(rule "JLCPCB: Trace Spacing (Outer Layer)"
 	(layer outer)
 	(condition "A.Type == 'Track' && B.Type == 'Track'")
 	(constraint clearance (min 0.09mm))
 )
 
-(rule "PCBWay: Trace Width (Inner Layer)"
+(rule "JLCPCB: Trace Width (Inner Layer)"
 	(layer inner)
 	(condition "A.Type == 'Track'")
-	(constraint track_width (min 0.1mm))
+	(constraint track_width (min 0.09mm))
 )
 
-(rule "PCBWay: Trace Spacing (Inner Layer)"
+(rule "JLCPCB: Trace Spacing (Inner Layer)"
 	(layer inner)
 	(condition "A.Type == 'Track' && B.Type == 'Track'")
-	(constraint clearance (min 0.1mm))
+	(constraint clearance (min 0.09mm))
 )
 
 
@@ -144,36 +176,36 @@
 #
 # WARNING: trace width/gap for a target impedance depend on YOUR stackup
 # (dielectric height, Dk, copper weight). The values below are typical
-# starting points for PCBWay's default stackup — verify against
-# PCBWay's impedance calculator for your actual order. Constraints use
+# starting points for JLCPCB's default stackup — verify against
+# JLCPCB's impedance calculator for your actual order. Constraints use
 # (opt ...) so they guide the router without raising nuisance DRC errors;
 # tighten to (min/max) once tuned. Assign nets to these classes in
 # Board Setup > Net Classes.
 
-(rule "PCBWay: 50R Single-Ended"
+(rule "JLCPCB: 50R Single-Ended"
 	(condition "A.NetClass == '50R'")
 	(constraint track_width (opt 0.2mm))
 )
 
-(rule "PCBWay: 60R_Diff Differential Pair"
+(rule "JLCPCB: 60R_Diff Differential Pair"
 	(condition "A.NetClass == '60R_Diff'")
 	(constraint track_width (opt 0.3mm))
 	(constraint diff_pair_gap (opt 0.15mm))
 )
 
-(rule "PCBWay: 90R_Diff Differential Pair"
+(rule "JLCPCB: 90R_Diff Differential Pair"
 	(condition "A.NetClass == '90R_Diff'")
 	(constraint track_width (opt 0.2mm))
 	(constraint diff_pair_gap (opt 0.13mm))
 )
 
-(rule "PCBWay: 100R_Diff Differential Pair"
+(rule "JLCPCB: 100R_Diff Differential Pair"
 	(condition "A.NetClass == '100R_Diff'")
 	(constraint track_width (opt 0.2mm))
 	(constraint diff_pair_gap (opt 0.2mm))
 )
 
-(rule "PCBWay: 120R_Diff Differential Pair"
+(rule "JLCPCB: 120R_Diff Differential Pair"
 	(condition "A.NetClass == '120R_Diff'")
 	(constraint track_width (opt 0.15mm))
 	(constraint diff_pair_gap (opt 0.2mm))
@@ -182,19 +214,19 @@
 
 # --- Legend ---
 
-(rule "PCBWay: Minimum Line Width"
+(rule "JLCPCB: Minimum Line Width"
 	(layer "?.Silkscreen")
 	(condition "A.Type == 'Text' || A.Type == 'Text Box'")
 	(constraint text_thickness (min 0.15mm))
 )
 
-(rule "PCBWay: Minimum Text Height"
+(rule "JLCPCB: Minimum Text Height"
 	(layer "?.Silkscreen")
 	(condition "A.Type == 'Text' || A.Type == 'Text Box'")
-	(constraint text_height (min 0.8mm))
+	(constraint text_height (min 1mm))
 )
 
-(rule "PCBWay: Pad to Silkscreen"
+(rule "JLCPCB: Pad to Silkscreen"
 	(condition "A.Type == 'Pad' && ((A.existsOnLayer('F.Mask') && B.Layer == 'F.Silkscreen') || (A.existsOnLayer('B.Mask') && B.Layer == 'B.Silkscreen'))")
 	(constraint silk_clearance (min 0.15mm))
 )
@@ -202,7 +234,7 @@
 
 # --- Board Outlines ---
 
-(rule "PCBWay: Trace to Board Edge"
+(rule "JLCPCB: Trace to Board Edge"
 	(condition "A.Type == 'Track'")
 	(constraint edge_clearance (min 0.3mm))
 )

--- a/JLCPCB/JLCPCB.kicad_dru
+++ b/JLCPCB/JLCPCB.kicad_dru
@@ -3,6 +3,9 @@
 #
 # Matching JLCPCB capabilities: https://jlcpcb.com/capabilities/pcb-capabilities
 #
+# This is the '4L-1oz' variant. If your order differs, use one of
+# the other variants (2L-1oz, 4L-2oz, 6L-1oz) — see the README table.
+#
 # GENERATED FILE — do not edit by hand.
 # Edit capabilities/JLCPCB.toml and run tools/generate_dru.py instead.
 #

--- a/JLCPCB/JLCPCB.kicad_dru
+++ b/JLCPCB/JLCPCB.kicad_dru
@@ -1,44 +1,27 @@
 (version 1)
-# Custom Design Rules (DRC) for KiCAD 8.0 (Stored in '<project>.kicad_dru' file).
+# Custom Design Rules (DRC) for KiCad — JLCPCB: 4 layer, 1oz outer / 0.5oz inner
 #
 # Matching JLCPCB capabilities: https://jlcpcb.com/capabilities/pcb-capabilities
 #
-# KiCad documentation: https://docs.kicad.org/master/id/pcbnew/pcbnew_advanced.html#custom_design_rules
+# GENERATED FILE — do not edit by hand.
+# Edit capabilities/JLCPCB.toml and run tools/generate_dru.py instead.
 #
-# Inspiration
-# - https://gist.github.com/darkxst/f713268e5469645425eed40115fb8b49 (with comments)
-# - https://gist.github.com/denniskupec/e163d13b0a64c2044bd259f64659485e (with comments)
+# KiCad documentation: https://docs.kicad.org/8.0/en/pcbnew/pcbnew.html#custom-design-rules
 
 
 # --- Drill/Hole Size ---
 
 (rule "JLCPCB: Drill Hole Size"
-  # Choose between:
-  # 1-2 Layers
-	# (constraint hole_size (min 0.3mm) (max 6.3mm))
-  # 4-6 Layers (more costly)
-	# (constraint hole_size (min 0.15mm) (max 6.3mm))
-  # 4-6 Layers (preferred)
 	(constraint hole_size (min 0.2mm) (max 6.3mm))
 )
 
 (rule "JLCPCB: Via Hole Size"
 	(condition "A.Type == 'Via'")
-  # Choose between:
-  # 1-2 Layers
-	# (constraint hole_size (min 0.3mm))
-  # 4-6 Layers (more costly)
-  # (constraint hole_size (min 0.15mm))
-  # 4-6 Layers (preferred)
 	(constraint hole_size (min 0.2mm))
 )
 
 (rule "JLCPCB: Via Annular Ring"
 	(condition "A.Type == 'Via'")
-  # Choose between:
-  # 1-6 Layers
-  # (constraint annular_width (min 0.05mm))
-  # 1-6 Layers (preferred)
 	(constraint annular_width (min 0.075mm))
 )
 
@@ -52,7 +35,6 @@
 	(constraint hole_size (min 0.5mm))
 )
 
-# TODO: Hole to board edge ≥ 1 mm. Min. board size 10 × 10 mm.
 (rule "JLCPCB: Castellated Hole Size"
 	(layer outer)
 	(condition "A.Type == 'Pad' && A.Fabrication_Property == 'Castellated pad'")
@@ -69,17 +51,16 @@
 	(constraint annular_width (min 0.25mm))
 )
 
-# An expensive 4-Wire Kelvin Test is automatically added for holes that are < 0.3mm with a diameter ≤ 0.4mm.
+# An expensive 4-Wire Kelvin Test is auto-added for holes < 0.3mm with diameter <= 0.4mm.
 (rule "JLCPCB: Avoid 4-Wire Kelvin Test"
 	(condition "(A.Type == 'Via' && A.Hole < 0.3mm && A.Diameter <= 0.4mm) || (A.Type == 'Pad' && ((A.Hole_Size_X < 0.3mm && A.Size_X <= 0.4mm) || (A.Hole_Size_Y < 0.3mm && A.Size_Y <= 0.4mm)))")
-  # 4-6 Layers
-  (constraint annular_width (min 0.125mm))
+	(constraint annular_width (min 0.125mm))
 )
 
 
-# --- VIA Support Rules --- 
+# --- VIA Support Rules ---
 
-(rule "JLCPCB: Only Throughhole VIAs are supported" 
+(rule "JLCPCB: Only Throughhole VIAs are supported"
 	(condition "A.Type == 'Via'")
 	(constraint assertion "!(A.isBlindBuriedVia() || A.isMicroVia())")
 )
@@ -87,14 +68,11 @@
 
 # --- Slot Width ---
 
-# JLCPCB: "The minimum plated slot width is 0.5mm, which is drawn with a pad."
 (rule "JLCPCB: Plated Slot Width"
 	(condition "A.Type == 'Pad' && (A.Hole_Size_X != A.Hole_Size_Y) && A.isPlated()")
 	(constraint hole_size (min 0.5mm))
 )
 
-# JLCPCB: "The minimum Non-Plated Slot Width is 1.0mm, please draw the slot
-# outline in the mechanical layer (GML or GKO)."
 (rule "JLCPCB: Non-Plated Slot Width"
 	(condition "A.Type == 'Pad' && (A.Hole_Size_X != A.Hole_Size_Y) && !A.isPlated()")
 	(constraint hole_size (min 1.0mm))
@@ -123,13 +101,13 @@
 	(constraint hole_to_hole (min 0.5mm))
 )
 
-# NOTE: This is not stated specifically, but is implied by other rules.
+# Not stated specifically, but implied by other rules.
 (rule "JLCPCB: Via/Pad to Via/Pad Clearance (Different Nets)"
 	(condition "(A.Type == 'Pad' || A.Type == 'Via') && (B.Type == 'Pad' || B.Type == 'Via') && A.Net != B.Net")
 	(constraint clearance (min 0.127mm))
 )
 
-# NOTE: This is not stated specifically, but is implied by other rules.
+# Not stated specifically, but implied by other rules.
 (rule "JLCPCB: Via/Pad Hole to Via/Pad Hole Clearance (Same Net)"
 	(condition "(A.Type == 'Pad' || A.Type == 'Via') && (B.Type == 'Pad' || B.Type == 'Via') && A.Net == B.Net")
 	(constraint hole_to_hole (min 0.254mm))
@@ -150,15 +128,17 @@
 	(constraint hole_clearance (min 0.254mm))
 )
 
+(rule "JLCPCB: NPTH to Copper (non-Track)"
+	(condition "A.Type == 'Pad' && A.Pad_Type == 'NPTH, mechanical' && !A.isPlated() && B.Type != 'Track'")
+	(constraint hole_clearance (min 0.2mm))
+)
+
 (rule "JLCPCB: Pad to Trace"
-	(condition "A.Type == 'Pad' && (A.Pad_Type == 'Through-hole' || A.Pad_Type == 'NPTH, mechanical') && B.Type == 'Track' &&  A.Net != B.Net")
+	(condition "A.Type == 'Pad' && (A.Pad_Type == 'Through-hole' || A.Pad_Type == 'NPTH, mechanical') && B.Type == 'Track' && A.Net != B.Net")
 	(constraint clearance (min 0.2mm))
 )
 
-# JLCPCB: "The minimum trace width & spacing under a BGA is 0.1mm(4mil)."
-# https://jlcpcb.com/help/article/BGA-Design-Guidelines---PCB-Layout-Recommendations-for-BGA-packages
-# Scoped to a "BGA" net class so only the BGA fan-out nets get the relaxed
-# clearance. Assign the relevant nets to a BGA net class in Board Setup > Net Classes.
+# BGA fan-out clearance. Assign BGA fan-out nets to a 'BGA' net class.
 (rule "JLCPCB: BGA to Trace"
 	(condition "A.NetClass == 'BGA' && B.Type == 'Track' && A.Net != B.Net")
 	(constraint clearance (min 0.1mm))
@@ -170,43 +150,65 @@
 (rule "JLCPCB: Trace Width (Outer Layer)"
 	(layer outer)
 	(condition "A.Type == 'Track'")
-  # Choose between:
-  # 1-2 Layers (1oz)
-  # (constraint track_width (min 0.127mm))
-  # 4-6 Layers (1oz and 0.5oz)
 	(constraint track_width (min 0.09mm))
-  # 1-6 Layers (2oz)
-  # (constraint track_width (min 0.2mm))
 )
+
 (rule "JLCPCB: Trace Spacing (Outer Layer)"
 	(layer outer)
 	(condition "A.Type == 'Track' && B.Type == 'Track'")
-  # Choose between:
-  # 1-2 Layers (1oz)
-  # (constraint clearance (min 0.127mm))
-  # 4-6 Layers (1oz and 0.5oz)
 	(constraint clearance (min 0.09mm))
-  # 1-6 Layers (2oz)
-  # (constraint clearance (min 0.2mm))
 )
 
 (rule "JLCPCB: Trace Width (Inner Layer)"
 	(layer inner)
 	(condition "A.Type == 'Track'")
-  # Choose between:
-  # 4-6 Layers (1oz and 0.5oz)
 	(constraint track_width (min 0.09mm))
-  # 4-6 Layers (2oz)
-  # (constraint track_width (min 0.2mm))
 )
+
 (rule "JLCPCB: Trace Spacing (Inner Layer)"
 	(layer inner)
 	(condition "A.Type == 'Track' && B.Type == 'Track'")
-  # Choose between:
-  # 4-6 Layers (1oz and 0.5oz)
 	(constraint clearance (min 0.09mm))
-  # 4-6 Layers (2oz)
-  # (constraint clearance (min 0.2mm))
+)
+
+
+# --- Impedance-Controlled Net Classes ---
+#
+# WARNING: trace width/gap for a target impedance depend on YOUR stackup
+# (dielectric height, Dk, copper weight). The values below are typical
+# starting points for JLCPCB's default stackup — verify against
+# JLCPCB's impedance calculator for your actual order. Constraints use
+# (opt ...) so they guide the router without raising nuisance DRC errors;
+# tighten to (min/max) once tuned. Assign nets to these classes in
+# Board Setup > Net Classes.
+
+(rule "JLCPCB: 50R Single-Ended"
+	(condition "A.NetClass == '50R'")
+	(constraint track_width (opt 0.2mm))
+)
+
+(rule "JLCPCB: 60R_Diff Differential Pair"
+	(condition "A.NetClass == '60R_Diff'")
+	(constraint track_width (opt 0.3mm))
+	(constraint diff_pair_gap (opt 0.15mm))
+)
+
+(rule "JLCPCB: 90R_Diff Differential Pair"
+	(condition "A.NetClass == '90R_Diff'")
+	(constraint track_width (opt 0.2mm))
+	(constraint diff_pair_gap (opt 0.13mm))
+)
+
+(rule "JLCPCB: 100R_Diff Differential Pair"
+	(condition "A.NetClass == '100R_Diff'")
+	(constraint track_width (opt 0.2mm))
+	(constraint diff_pair_gap (opt 0.2mm))
+)
+
+(rule "JLCPCB: 120R_Diff Differential Pair"
+	(condition "A.NetClass == '120R_Diff'")
+	(constraint track_width (opt 0.15mm))
+	(constraint diff_pair_gap (opt 0.2mm))
 )
 
 
@@ -225,7 +227,7 @@
 )
 
 (rule "JLCPCB: Pad to Silkscreen"
-	(condition "A.Type == 'Pad' && ((A.existsOnLayer('F.Mask') && B.Layer == 'F.Silkscreen') || (A.existsOnLayer('B.Mask') && B.Layer == 'B.Silkscreen')) ")
+	(condition "A.Type == 'Pad' && ((A.existsOnLayer('F.Mask') && B.Layer == 'F.Silkscreen') || (A.existsOnLayer('B.Mask') && B.Layer == 'B.Silkscreen'))")
 	(constraint silk_clearance (min 0.15mm))
 )
 
@@ -234,9 +236,5 @@
 
 (rule "JLCPCB: Trace to Board Edge"
 	(condition "A.Type == 'Track'")
-  # Choose between:
-  # Routed
 	(constraint edge_clearance (min 0.3mm))
-  # V-Cut Panel
-	# (constraint edge_clearance (min 0.4mm))
 )

--- a/PCBWay/PCBWay-2L-1oz.kicad_dru
+++ b/PCBWay/PCBWay-2L-1oz.kicad_dru
@@ -1,5 +1,5 @@
 (version 1)
-# Custom Design Rules (DRC) for KiCad — PCBWay: 4 layer, 1oz outer / 0.5oz inner
+# Custom Design Rules (DRC) for KiCad — PCBWay: 1-2 layer, 1oz copper
 #
 # Matching PCBWay capabilities: https://www.pcbway.com/capabilities.html
 #
@@ -17,7 +17,7 @@
 
 (rule "PCBWay: Via Hole Size"
 	(condition "A.Type == 'Via'")
-	(constraint hole_size (min 0.2mm))
+	(constraint hole_size (min 0.3mm))
 )
 
 (rule "PCBWay: Via Annular Ring"
@@ -118,25 +118,13 @@
 (rule "PCBWay: Trace Width (Outer Layer)"
 	(layer outer)
 	(condition "A.Type == 'Track'")
-	(constraint track_width (min 0.09mm))
+	(constraint track_width (min 0.127mm))
 )
 
 (rule "PCBWay: Trace Spacing (Outer Layer)"
 	(layer outer)
 	(condition "A.Type == 'Track' && B.Type == 'Track'")
-	(constraint clearance (min 0.09mm))
-)
-
-(rule "PCBWay: Trace Width (Inner Layer)"
-	(layer inner)
-	(condition "A.Type == 'Track'")
-	(constraint track_width (min 0.1mm))
-)
-
-(rule "PCBWay: Trace Spacing (Inner Layer)"
-	(layer inner)
-	(condition "A.Type == 'Track' && B.Type == 'Track'")
-	(constraint clearance (min 0.1mm))
+	(constraint clearance (min 0.127mm))
 )
 
 

--- a/PCBWay/PCBWay-2L-1oz.kicad_dru
+++ b/PCBWay/PCBWay-2L-1oz.kicad_dru
@@ -3,6 +3,9 @@
 #
 # Matching PCBWay capabilities: https://www.pcbway.com/capabilities.html
 #
+# This is the '2L-1oz' variant. If your order differs, use one of
+# the other variants (4L-1oz, 4L-2oz, 6L-1oz) — see the README table.
+#
 # GENERATED FILE — do not edit by hand.
 # Edit capabilities/PCBWay.toml and run tools/generate_dru.py instead.
 #

--- a/PCBWay/PCBWay-4L-2oz.kicad_dru
+++ b/PCBWay/PCBWay-4L-2oz.kicad_dru
@@ -1,5 +1,5 @@
 (version 1)
-# Custom Design Rules (DRC) for KiCad — PCBWay: 4 layer, 1oz outer / 0.5oz inner
+# Custom Design Rules (DRC) for KiCad — PCBWay: 4 layer, 2oz copper
 #
 # Matching PCBWay capabilities: https://www.pcbway.com/capabilities.html
 #
@@ -118,25 +118,25 @@
 (rule "PCBWay: Trace Width (Outer Layer)"
 	(layer outer)
 	(condition "A.Type == 'Track'")
-	(constraint track_width (min 0.09mm))
+	(constraint track_width (min 0.1524mm))
 )
 
 (rule "PCBWay: Trace Spacing (Outer Layer)"
 	(layer outer)
 	(condition "A.Type == 'Track' && B.Type == 'Track'")
-	(constraint clearance (min 0.09mm))
+	(constraint clearance (min 0.1778mm))
 )
 
 (rule "PCBWay: Trace Width (Inner Layer)"
 	(layer inner)
 	(condition "A.Type == 'Track'")
-	(constraint track_width (min 0.1mm))
+	(constraint track_width (min 0.1524mm))
 )
 
 (rule "PCBWay: Trace Spacing (Inner Layer)"
 	(layer inner)
 	(condition "A.Type == 'Track' && B.Type == 'Track'")
-	(constraint clearance (min 0.1mm))
+	(constraint clearance (min 0.1778mm))
 )
 
 

--- a/PCBWay/PCBWay-4L-2oz.kicad_dru
+++ b/PCBWay/PCBWay-4L-2oz.kicad_dru
@@ -3,6 +3,9 @@
 #
 # Matching PCBWay capabilities: https://www.pcbway.com/capabilities.html
 #
+# This is the '4L-2oz' variant. If your order differs, use one of
+# the other variants (2L-1oz, 4L-1oz, 6L-1oz) — see the README table.
+#
 # GENERATED FILE — do not edit by hand.
 # Edit capabilities/PCBWay.toml and run tools/generate_dru.py instead.
 #

--- a/PCBWay/PCBWay-6L-1oz.kicad_dru
+++ b/PCBWay/PCBWay-6L-1oz.kicad_dru
@@ -3,6 +3,9 @@
 #
 # Matching PCBWay capabilities: https://www.pcbway.com/capabilities.html
 #
+# This is the '6L-1oz' variant. If your order differs, use one of
+# the other variants (2L-1oz, 4L-1oz, 4L-2oz) — see the README table.
+#
 # GENERATED FILE — do not edit by hand.
 # Edit capabilities/PCBWay.toml and run tools/generate_dru.py instead.
 #

--- a/PCBWay/PCBWay-6L-1oz.kicad_dru
+++ b/PCBWay/PCBWay-6L-1oz.kicad_dru
@@ -1,5 +1,5 @@
 (version 1)
-# Custom Design Rules (DRC) for KiCad — PCBWay: 4 layer, 1oz outer / 0.5oz inner
+# Custom Design Rules (DRC) for KiCad — PCBWay: 6 layer, 1oz outer / 0.5oz inner
 #
 # Matching PCBWay capabilities: https://www.pcbway.com/capabilities.html
 #

--- a/PCBWay/PCBWay.kicad_dru
+++ b/PCBWay/PCBWay.kicad_dru
@@ -3,6 +3,9 @@
 #
 # Matching PCBWay capabilities: https://www.pcbway.com/capabilities.html
 #
+# This is the '4L-1oz' variant. If your order differs, use one of
+# the other variants (2L-1oz, 4L-2oz, 6L-1oz) — see the README table.
+#
 # GENERATED FILE — do not edit by hand.
 # Edit capabilities/PCBWay.toml and run tools/generate_dru.py instead.
 #

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ The rule files are **generated** from a single source of truth per fab (`capabil
 
 > **Editing rules:** change `capabilities/<FAB>.toml` and re-run `python3 tools/generate_dru.py`. Do **not** hand-edit the generated `.kicad_dru` files — CI regenerates and fails if they drift from the source.
 
+See [COMPARISON.md](COMPARISON.md) for a side-by-side of every fab's rule values (also generated from the same source).
+
 ## Use in your project
 
 1. Copy the `.kicad_dru` matching your order from `JLCPCB/` or `PCBWay/` into your KiCad project folder.

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ The linter is a fast syntax/consistency gate — KiCad has no standalone `.kicad
 kicad-cli pcb drc --exit-code-violations --severity-error JLCPCB/JLCPCB.kicad_pcb
 ```
 
+A separate **DRC** workflow (`.github/workflows/drc.yml`) installs KiCad and runs this against each fab's default board on demand and on board/rule changes, publishing the report as an artifact. It's **informational, not a gate** — the test boards intentionally contain passing and failing footprints, so violations are expected.
+
 ## KiCad documentation
 
 - [Custom Design Rules (8.0)](https://docs.kicad.org/8.0/en/pcbnew/pcbnew.html#custom-design-rules) — the syntax these rules are written against

--- a/README.md
+++ b/README.md
@@ -13,25 +13,43 @@ The rules are authored against the KiCad 8 custom-rules syntax and are forward-c
 | JLCPCB | [`JLCPCB/`](JLCPCB/)  | https://jlcpcb.com/capabilities/pcb-capabilities  |
 | PCBWay | [`PCBWay/`](PCBWay/)  | https://www.pcbway.com/capabilities.html          |
 
-Each folder contains:
+Each folder contains one `.kicad_dru` per build variant, plus a small test board (`.kicad_pcb`, `.kicad_sch`, `.kicad_pro`) exercising the rules.
 
-- `<FAB>.kicad_dru` — the rule file you copy into your project
-- `<FAB>.kicad_pcb`, `.kicad_sch`, `.kicad_pro` — a small test board exercising the rules
+The rule files are **generated** from a single source of truth per fab (`capabilities/<FAB>.toml`) by `tools/generate_dru.py` — so there are no "uncomment the right variant" comment blocks to get wrong. Pick the whole file that matches what you're ordering:
+
+| File | Layers | Copper |
+|------|--------|--------|
+| `<FAB>.kicad_dru` | 4 (recommended default) | 1oz |
+| `<FAB>-2L-1oz.kicad_dru` | 1–2 | 1oz |
+| `<FAB>-4L-2oz.kicad_dru` | 4 | 2oz |
+| `<FAB>-6L-1oz.kicad_dru` | 6 | 1oz |
+
+> **Editing rules:** change `capabilities/<FAB>.toml` and re-run `python3 tools/generate_dru.py`. Do **not** hand-edit the generated `.kicad_dru` files — CI regenerates and fails if they drift from the source.
 
 ## Use in your project
 
-1. Copy the relevant `.kicad_dru` from `JLCPCB/` or `PCBWay/` into your KiCad project folder.
+1. Copy the `.kicad_dru` matching your order from `JLCPCB/` or `PCBWay/` into your KiCad project folder.
 2. Rename it to match your project: `your-project.kicad_dru`.
 3. KiCad picks it up automatically. View under `File > Board Setup > Design Rules > Custom Rules`.
 4. Run `Inspect > Design Rules Checker` (or press F8) to apply.
 
-Many rules have alternates commented out for different layer counts or copper weights. Read the comments at the top of each rule and uncomment the variant that matches what you're ordering.
+### Impedance-controlled routing
+
+Every file ships net classes for impedance-controlled routing: `50R` (single-ended) and `60R_Diff` / `90R_Diff` / `100R_Diff` / `120R_Diff` (differential). Assign nets to the matching class in `Board Setup > Net Classes`; unassigned classes do nothing.
+
+> ⚠️ The shipped width/gap values are **typical starting points for the fab's default stackup**. Impedance depends on your actual stackup — verify against the fab's impedance calculator and adjust the values for your order.
 
 ## Validation
 
-Every `.kicad_dru` file is checked in CI by a small linter (`tools/lint_dru.py`, no dependencies) that catches malformed s-expressions, missing `(version 1)` headers, rules with no constraint, duplicate names, wrong fab prefixes, and lowercase item-type literals (`'track'`/`'via'`/`'pad'`) that KiCad silently never matches. Run it locally with:
+CI does two checks (both dependency-free Python):
+
+- **In-sync** — `python3 tools/generate_dru.py --check` fails if the committed `.kicad_dru` files don't match what `capabilities/*.toml` would generate.
+- **Lint** — `tools/lint_dru.py` catches malformed s-expressions, missing `(version 1)` headers, rules with no constraint, duplicate names, wrong fab prefixes, and lowercase item-type literals (`'track'`/`'via'`/`'pad'`) that KiCad silently never matches.
+
+Run them locally with:
 
 ```
+python3 tools/generate_dru.py --check
 python3 tools/lint_dru.py
 ```
 

--- a/capabilities/JLCPCB.toml
+++ b/capabilities/JLCPCB.toml
@@ -1,0 +1,125 @@
+# Source of truth for JLCPCB design rules.
+#
+# Values are seeded from the previously hand-maintained JLCPCB.kicad_dru (which
+# tracked https://jlcpcb.com/capabilities/pcb-capabilities). Concrete .kicad_dru
+# files are generated from this file by tools/generate_dru.py — do not hand-edit
+# the generated output.
+
+[fab]
+name = "JLCPCB"
+prefix = "JLCPCB"
+capabilities_url = "https://jlcpcb.com/capabilities/pcb-capabilities"
+default_variant = "4L-1oz"   # gets the plainly-named JLCPCB/JLCPCB.kicad_dru
+
+[flags]
+avoid_kelvin_test = true       # JLCPCB adds an expensive 4-wire Kelvin test for tiny holes
+allow_blind_buried = false     # standard process: through-hole vias only
+emit_implied_clearance = true  # emit the not-explicitly-stated catch-all clearances
+emit_bga = true                # emit the BGA fan-out clearance rule
+
+# Values that do not change between variants.
+[constants]
+drill_hole_max     = "6.3mm"
+via_annular        = "0.075mm"
+pth_hole_min       = "0.2mm"
+pth_hole_max       = "6.3mm"
+npth_hole_min      = "0.5mm"
+castellated_min    = "0.6mm"
+pth_annular        = "0.075mm"
+npth_annular       = "0.25mm"
+kelvin_annular     = "0.125mm"
+plated_slot_min    = "0.5mm"
+nonplated_slot_min = "1.0mm"
+hole_to_hole_diff  = "0.5mm"
+via_same_net       = "0.254mm"
+pad_nohole_diff    = "0.127mm"
+pad_hole_diff      = "0.5mm"
+implied_diff       = "0.127mm"
+implied_same_net   = "0.254mm"
+via_to_trace       = "0.254mm"
+pth_to_trace       = "0.33mm"
+npth_to_trace      = "0.254mm"
+npth_to_copper     = "0.2mm"
+pad_to_trace       = "0.2mm"
+bga_to_trace       = "0.1mm"
+text_thickness     = "0.15mm"
+text_height        = "1mm"
+silk_clearance     = "0.15mm"
+edge_routed        = "0.3mm"
+
+[[variant]]
+id = "2L-1oz"
+label = "1-2 layer, 1oz copper"
+layers = 2
+[variant.over]
+drill_hole_min      = "0.3mm"
+via_hole            = "0.3mm"
+trace_width_outer   = "0.127mm"
+trace_spacing_outer = "0.127mm"
+
+[[variant]]
+id = "4L-1oz"
+label = "4 layer, 1oz outer / 0.5oz inner"
+layers = 4
+[variant.over]
+drill_hole_min      = "0.2mm"
+via_hole            = "0.2mm"
+trace_width_outer   = "0.09mm"
+trace_spacing_outer = "0.09mm"
+trace_width_inner   = "0.09mm"
+trace_spacing_inner = "0.09mm"
+
+[[variant]]
+id = "4L-2oz"
+label = "4 layer, 2oz copper"
+layers = 4
+[variant.over]
+drill_hole_min      = "0.2mm"
+via_hole            = "0.2mm"
+trace_width_outer   = "0.2mm"
+trace_spacing_outer = "0.2mm"
+trace_width_inner   = "0.2mm"
+trace_spacing_inner = "0.2mm"
+
+[[variant]]
+id = "6L-1oz"
+label = "6 layer, 1oz outer / 0.5oz inner"
+layers = 6
+[variant.over]
+drill_hole_min      = "0.2mm"
+via_hole            = "0.2mm"
+trace_width_outer   = "0.09mm"
+trace_spacing_outer = "0.09mm"
+trace_width_inner   = "0.09mm"
+trace_spacing_inner = "0.09mm"
+
+# Impedance-controlled net classes. Typical starting values for JLCPCB's default
+# stackup — see the warning emitted into each file; tune to your actual stackup.
+[[diffpair]]
+name = "50R"
+diff = false
+track_width = "0.2mm"
+
+[[diffpair]]
+name = "60R_Diff"
+diff = true
+track_width = "0.3mm"
+gap = "0.15mm"
+
+[[diffpair]]
+name = "90R_Diff"
+diff = true
+track_width = "0.2mm"
+gap = "0.13mm"
+
+[[diffpair]]
+name = "100R_Diff"
+diff = true
+track_width = "0.2mm"
+gap = "0.2mm"
+
+[[diffpair]]
+name = "120R_Diff"
+diff = true
+track_width = "0.15mm"
+gap = "0.2mm"

--- a/capabilities/PCBWay.toml
+++ b/capabilities/PCBWay.toml
@@ -1,0 +1,117 @@
+# Source of truth for PCBWay design rules.
+#
+# Values are seeded from the previously hand-maintained PCBWay.kicad_dru (which
+# tracked https://www.pcbway.com/capabilities.html). Concrete .kicad_dru files
+# are generated from this file by tools/generate_dru.py — do not hand-edit the
+# generated output.
+
+[fab]
+name = "PCBWay"
+prefix = "PCBWay"
+capabilities_url = "https://www.pcbway.com/capabilities.html"
+default_variant = "4L-1oz"   # gets the plainly-named PCBWay/PCBWay.kicad_dru
+
+[flags]
+avoid_kelvin_test = false      # not a PCBWay process quirk
+allow_blind_buried = true      # PCBWay offers blind/buried vias (advanced) — no assertion
+emit_implied_clearance = false
+emit_bga = false               # PCBWay BGA spec not yet sourced
+
+[constants]
+drill_hole_min     = "0.15mm"
+drill_hole_max     = "6.3mm"
+via_annular        = "0.15mm"
+pth_hole_min       = "0.2mm"
+pth_hole_max       = "6.35mm"
+npth_hole_min      = "0.5mm"
+castellated_min    = "0.6mm"
+pth_annular        = "0.15mm"
+npth_annular       = "0.25mm"
+plated_slot_min    = "0.5mm"
+nonplated_slot_min = "0.8mm"
+hole_to_hole_diff  = "0.5mm"
+via_same_net       = "0.254mm"
+pad_nohole_diff    = "0.127mm"
+pad_hole_diff      = "0.5mm"
+via_to_trace       = "0.254mm"
+pth_to_trace       = "0.33mm"
+npth_to_trace      = "0.254mm"
+npth_to_copper     = "0.20mm"
+pad_to_trace       = "0.2mm"
+text_thickness     = "0.15mm"
+text_height        = "0.8mm"
+silk_clearance     = "0.15mm"
+edge_routed        = "0.3mm"
+
+[[variant]]
+id = "2L-1oz"
+label = "1-2 layer, 1oz copper"
+layers = 2
+[variant.over]
+via_hole            = "0.3mm"
+trace_width_outer   = "0.127mm"
+trace_spacing_outer = "0.127mm"
+
+[[variant]]
+id = "4L-1oz"
+label = "4 layer, 1oz outer / 0.5oz inner"
+layers = 4
+[variant.over]
+via_hole            = "0.2mm"
+trace_width_outer   = "0.09mm"
+trace_spacing_outer = "0.09mm"
+trace_width_inner   = "0.1mm"
+trace_spacing_inner = "0.1mm"
+
+[[variant]]
+id = "4L-2oz"
+label = "4 layer, 2oz copper"
+layers = 4
+[variant.over]
+via_hole            = "0.2mm"
+trace_width_outer   = "0.1524mm"
+trace_spacing_outer = "0.1778mm"
+trace_width_inner   = "0.1524mm"
+trace_spacing_inner = "0.1778mm"
+
+[[variant]]
+id = "6L-1oz"
+label = "6 layer, 1oz outer / 0.5oz inner"
+layers = 6
+[variant.over]
+via_hole            = "0.2mm"
+trace_width_outer   = "0.09mm"
+trace_spacing_outer = "0.09mm"
+trace_width_inner   = "0.1mm"
+trace_spacing_inner = "0.1mm"
+
+# Impedance-controlled net classes. Typical starting values for PCBWay's default
+# stackup — see the warning emitted into each file; tune to your actual stackup.
+[[diffpair]]
+name = "50R"
+diff = false
+track_width = "0.2mm"
+
+[[diffpair]]
+name = "60R_Diff"
+diff = true
+track_width = "0.3mm"
+gap = "0.15mm"
+
+[[diffpair]]
+name = "90R_Diff"
+diff = true
+track_width = "0.2mm"
+gap = "0.13mm"
+
+[[diffpair]]
+name = "100R_Diff"
+diff = true
+track_width = "0.2mm"
+gap = "0.2mm"
+
+[[diffpair]]
+name = "120R_Diff"
+diff = true
+track_width = "0.15mm"
+gap = "0.2mm"

--- a/tools/gen_comparison.py
+++ b/tools/gen_comparison.py
@@ -15,7 +15,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import tomllib  # noqa: E402  (stdlib, 3.11+)
-from generate_dru import Fab, ROOT  # noqa: E402
+from generate_dru import Fab, ROOT, validate  # noqa: E402
 
 OUT = os.path.join(ROOT, "COMPARISON.md")
 
@@ -69,7 +69,9 @@ def load_fabs() -> list:
     fabs = []
     for tp in sorted(glob.glob(os.path.join(ROOT, "capabilities", "*.toml"))):
         with open(tp, "rb") as fh:
-            fabs.append(Fab(tomllib.load(fh)))
+            fab = Fab(tomllib.load(fh))
+        validate(fab)
+        fabs.append(fab)
     return fabs
 
 

--- a/tools/gen_comparison.py
+++ b/tools/gen_comparison.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Generate COMPARISON.md — a side-by-side table of every fab's rule values,
+read from the same capabilities/*.toml source of truth as the .kicad_dru files.
+
+Usage:
+    python3 tools/gen_comparison.py            # (re)write COMPARISON.md
+    python3 tools/gen_comparison.py --check     # fail if COMPARISON.md is stale
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import tomllib  # noqa: E402  (stdlib, 3.11+)
+from generate_dru import Fab, ROOT  # noqa: E402
+
+OUT = os.path.join(ROOT, "COMPARISON.md")
+
+# (toml key, human label) for values that don't vary by variant.
+CONSTANT_ROWS = [
+    ("drill_hole_max", "Drill hole — max"),
+    ("via_annular", "Via annular ring — min"),
+    ("pth_hole_min", "PTH hole — min"),
+    ("pth_hole_max", "PTH hole — max"),
+    ("npth_hole_min", "NPTH hole — min"),
+    ("castellated_min", "Castellated hole — min"),
+    ("pth_annular", "PTH annular ring — min"),
+    ("npth_annular", "NPTH annular ring — min"),
+    ("plated_slot_min", "Plated slot width — min"),
+    ("nonplated_slot_min", "Non-plated slot width — min"),
+    ("hole_to_hole_diff", "Hole-to-hole, different nets"),
+    ("via_same_net", "Via hole-to-hole, same net"),
+    ("pad_nohole_diff", "Pad-to-pad (no hole), different nets"),
+    ("pad_hole_diff", "Pad hole-to-hole (with hole), different nets"),
+    ("via_to_trace", "Via hole to trace"),
+    ("pth_to_trace", "PTH hole to trace"),
+    ("npth_to_trace", "NPTH hole to trace"),
+    ("npth_to_copper", "NPTH to copper (non-track)"),
+    ("pad_to_trace", "Pad to trace"),
+    ("bga_to_trace", "BGA to trace"),
+    ("text_thickness", "Silk line width — min"),
+    ("text_height", "Silk text height — min"),
+    ("silk_clearance", "Pad to silkscreen"),
+    ("edge_routed", "Trace to board edge (routed)"),
+]
+
+# Values that vary by variant.
+VARIANT_ROWS = [
+    ("drill_hole_min", "Drill hole — min"),
+    ("via_hole", "Via hole — min"),
+    ("trace_width_outer", "Trace width (outer)"),
+    ("trace_spacing_outer", "Trace spacing (outer)"),
+    ("trace_width_inner", "Trace width (inner)"),
+    ("trace_spacing_inner", "Trace spacing (inner)"),
+]
+
+FLAG_ROWS = [
+    ("avoid_kelvin_test", "Avoids JLCPCB 4-wire Kelvin test"),
+    ("allow_blind_buried", "Blind/buried vias allowed"),
+    ("emit_bga", "Ships a BGA fan-out rule"),
+    ("emit_implied_clearance", "Ships implied catch-all clearances"),
+]
+
+
+def load_fabs() -> list:
+    fabs = []
+    for tp in sorted(glob.glob(os.path.join(ROOT, "capabilities", "*.toml"))):
+        with open(tp, "rb") as fh:
+            fabs.append(Fab(tomllib.load(fh)))
+    return fabs
+
+
+def merged(fab: Fab, variant: dict) -> dict:
+    m = dict(fab.constants)
+    m.update(variant.get("over", {}))
+    return m
+
+
+def variant_by_id(fab: Fab, vid: str) -> dict:
+    for v in fab.variants:
+        if v["id"] == vid:
+            return v
+    return fab.variants[0]
+
+
+def table(headers: list, rows: list) -> str:
+    out = ["| " + " | ".join(headers) + " |",
+           "|" + "|".join("---" for _ in headers) + "|"]
+    for r in rows:
+        out.append("| " + " | ".join(r) + " |")
+    return "\n".join(out)
+
+
+def render(fabs: list) -> str:
+    names = [f.name for f in fabs]
+    doc = []
+    doc.append("# Fab capability comparison")
+    doc.append("")
+    doc.append("<!-- GENERATED FILE — do not edit by hand. -->")
+    doc.append("<!-- Run tools/gen_comparison.py after editing capabilities/*.toml. -->")
+    doc.append("")
+    doc.append("Side-by-side of the design-rule values each fab enforces, read from "
+               "`capabilities/*.toml`. All values in mm unless noted.")
+    doc.append("")
+
+    # Constants (resolved at each fab's default variant so variant-only keys fill in).
+    defaults = {f.name: merged(f, variant_by_id(f, f.default_variant)) for f in fabs}
+    doc.append("## Fixed limits")
+    doc.append("")
+    doc.append(f"Shown at each fab's default variant "
+               + ", ".join(f"**{f.name}**: `{f.default_variant}`" for f in fabs) + ".")
+    doc.append("")
+    rows = []
+    for key, label in CONSTANT_ROWS:
+        cells = [defaults[n].get(key, "—") for n in names]
+        if all(c == "—" for c in cells):
+            continue
+        rows.append([label] + cells)
+    doc.append(table(["Parameter"] + names, rows))
+    doc.append("")
+
+    # Per-variant values.
+    doc.append("## By build variant")
+    doc.append("")
+    for f in fabs:
+        doc.append(f"### {f.name}")
+        doc.append("")
+        headers = ["Variant"] + [lbl for _, lbl in VARIANT_ROWS]
+        rows = []
+        for v in f.variants:
+            m = merged(f, v)
+            marker = " (default)" if v["id"] == f.default_variant else ""
+            rows.append([f"`{v['id']}`{marker}"] + [m.get(k, "—") for k, _ in VARIANT_ROWS])
+        doc.append(table(headers, rows))
+        doc.append("")
+
+    # Impedance-controlled net classes.
+    doc.append("## Impedance-controlled net classes")
+    doc.append("")
+    doc.append("> Typical starting values for each fab's default stackup — **verify against "
+               "the fab's impedance calculator for your actual stackup.**")
+    doc.append("")
+    class_names = []
+    for f in fabs:
+        for dp in f.diffpairs:
+            if dp["name"] not in class_names:
+                class_names.append(dp["name"])
+    headers = ["Net class"] + [f"{n} (width / gap)" for n in names]
+    rows = []
+    for cn in class_names:
+        cells = []
+        for f in fabs:
+            dp = next((d for d in f.diffpairs if d["name"] == cn), None)
+            if dp is None:
+                cells.append("—")
+            elif dp.get("diff"):
+                cells.append(f"{dp['track_width']} / {dp['gap']}")
+            else:
+                cells.append(f"{dp['track_width']} / n/a")
+        rows.append([f"`{cn}`"] + cells)
+    doc.append(table(headers, rows))
+    doc.append("")
+
+    # Process notes / flags.
+    doc.append("## Process notes")
+    doc.append("")
+    rows = []
+    for key, label in FLAG_ROWS:
+        rows.append([label] + ["yes" if f.flags.get(key) else "no" for f in fabs])
+    doc.append(table(["", *names], rows))
+    doc.append("")
+
+    return "\n".join(doc) + "\n"
+
+
+def main(argv: list) -> int:
+    check = "--check" in argv[1:]
+    fabs = load_fabs()
+    if not fabs:
+        print("no capabilities/*.toml files found", file=sys.stderr)
+        return 1
+    text = render(fabs)
+
+    existing = None
+    if os.path.exists(OUT):
+        with open(OUT, "r", encoding="utf-8") as fh:
+            existing = fh.read()
+
+    if check:
+        if existing != text:
+            print("COMPARISON.md is out of date; run tools/gen_comparison.py", file=sys.stderr)
+            return 1
+        print("COMPARISON.md is up to date.")
+        return 0
+
+    with open(OUT, "w", encoding="utf-8") as fh:
+        fh.write(text)
+    print(f"wrote {os.path.relpath(OUT, ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tools/generate_dru.py
+++ b/tools/generate_dru.py
@@ -117,6 +117,11 @@ def generate(fab: Fab, variant: dict) -> str:
     out.append(f"# Custom Design Rules (DRC) for KiCad — {fab.name}: {variant['label']}")
     out.append("#")
     out.append(f"# Matching {fab.name} capabilities: {fab.url}")
+    others = [v["id"] for v in fab.variants if v.get("id") != variant.get("id")]
+    if others:
+        out.append("#")
+        out.append(f"# This is the '{variant['id']}' variant. If your order differs, use one of")
+        out.append(f"# the other variants ({', '.join(others)}) — see the README table.")
     out.append("#")
     out.append("# GENERATED FILE — do not edit by hand.")
     out.append(f"# Edit capabilities/{fab.name}.toml and run tools/generate_dru.py instead.")

--- a/tools/generate_dru.py
+++ b/tools/generate_dru.py
@@ -40,7 +40,7 @@ class Fab:
         self.diffpairs = data.get("diffpair", [])
 
 
-def make_val(constants: dict, over: dict):
+def make_val(constants: dict, over: dict, label: str = ""):
     """Return a lookup that prefers the variant override, then the constant."""
 
     def val(key: str) -> str:
@@ -48,9 +48,47 @@ def make_val(constants: dict, over: dict):
             return over[key]
         if key in constants:
             return constants[key]
-        raise KeyError(f"missing value for '{key}'")
+        where = f" for {label}" if label else ""
+        raise KeyError(f"missing value '{key}'{where} — add it to the fab's TOML")
 
     return val
+
+
+# Flags that, when set, require these value keys to be present.
+FLAG_REQUIRES = {
+    "avoid_kelvin_test": ["kelvin_annular"],
+    "emit_implied_clearance": ["implied_diff", "implied_same_net"],
+    "emit_bga": ["bga_to_trace"],
+}
+
+
+def validate(fab: Fab) -> None:
+    """Fail early and clearly on TOML mistakes rather than deep in generation."""
+    if not fab.variants:
+        raise ValueError(f"{fab.name}: no [[variant]] blocks defined")
+
+    ids = [v.get("id") for v in fab.variants]
+    if None in ids:
+        raise ValueError(f"{fab.name}: every [[variant]] needs an id")
+    if len(set(ids)) != len(ids):
+        raise ValueError(f"{fab.name}: duplicate variant ids in {ids}")
+    if fab.default_variant not in ids:
+        raise ValueError(
+            f"{fab.name}: default_variant '{fab.default_variant}' is not one of {ids}")
+
+    for flag, keys in FLAG_REQUIRES.items():
+        if fab.flags.get(flag):
+            missing = [k for k in keys if k not in fab.constants]
+            if missing:
+                raise ValueError(
+                    f"{fab.name}: flag '{flag}' is set but [constants] is missing {missing}")
+
+    for dp in fab.diffpairs:
+        if "name" not in dp or "track_width" not in dp:
+            raise ValueError(f"{fab.name}: every [[diffpair]] needs a name and track_width")
+        if dp.get("diff") and "gap" not in dp:
+            raise ValueError(
+                f"{fab.name}: differential net class '{dp['name']}' needs a gap")
 
 
 def rule(name: str, condition: str, constraints: list, comment: str = "", layer: str = "") -> str:
@@ -70,7 +108,7 @@ def rule(name: str, condition: str, constraints: list, comment: str = "", layer:
 def generate(fab: Fab, variant: dict) -> str:
     p = fab.prefix
     over = variant.get("over", {})
-    val = make_val(fab.constants, over)
+    val = make_val(fab.constants, over, f"{fab.name} {variant.get('id', '?')}")
     layers = variant.get("layers", 2)
     has_inner = layers > 2
 
@@ -272,9 +310,19 @@ def main(argv: list) -> int:
     for tp in toml_paths:
         with open(tp, "rb") as fh:
             fab = Fab(tomllib.load(fh))
+        validate(fab)
+
+        expected = {}
         for variant in fab.variants:
-            text = generate(fab, variant)
-            path = output_path(fab, variant)
+            expected[output_path(fab, variant)] = generate(fab, variant)
+
+        # Orphans: .kicad_dru files in the fab's dir that we no longer generate
+        # (e.g. left behind after a variant was renamed or removed).
+        fab_dir = os.path.join(ROOT, fab.name)
+        on_disk = set(glob.glob(os.path.join(fab_dir, "*.kicad_dru")))
+        orphans = sorted(on_disk - set(expected))
+
+        for path, text in expected.items():
             existing = None
             if os.path.exists(path):
                 with open(path, "r", encoding="utf-8") as fh:
@@ -287,6 +335,14 @@ def main(argv: list) -> int:
                 with open(path, "w", encoding="utf-8") as fh:
                     fh.write(text)
                 written.append(os.path.relpath(path, ROOT))
+
+        for orphan in orphans:
+            rel = os.path.relpath(orphan, ROOT)
+            if check:
+                stale.append(f"{rel} (orphaned — no matching variant)")
+            else:
+                os.remove(orphan)
+                print(f"removed orphan {rel}")
 
     if check:
         if stale:

--- a/tools/generate_dru.py
+++ b/tools/generate_dru.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Generate KiCad .kicad_dru files from per-fab TOML source-of-truth files.
+
+Reads every capabilities/<FAB>.toml and emits one .kicad_dru per variant into
+<FAB>/. The default variant gets the plainly-named <FAB>/<FAB>.kicad_dru; the
+others get <FAB>/<FAB>-<id>.kicad_dru.
+
+Rule *structure* (names, conditions, order) lives here; rule *values* live in
+the TOML. No third-party dependencies — TOML is read with the stdlib tomllib
+(Python 3.11+).
+
+Usage:
+    python3 tools/generate_dru.py            # regenerate everything
+    python3 tools/generate_dru.py --check    # fail if output is out of date
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+import sys
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover
+    sys.exit("generate_dru.py needs Python 3.11+ (stdlib tomllib)")
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+class Fab:
+    def __init__(self, data: dict):
+        self.name = data["fab"]["name"]
+        self.prefix = data["fab"]["prefix"]
+        self.url = data["fab"]["capabilities_url"]
+        self.default_variant = data["fab"]["default_variant"]
+        self.flags = data.get("flags", {})
+        self.constants = data.get("constants", {})
+        self.variants = data.get("variant", [])
+        self.diffpairs = data.get("diffpair", [])
+
+
+def make_val(constants: dict, over: dict):
+    """Return a lookup that prefers the variant override, then the constant."""
+
+    def val(key: str) -> str:
+        if key in over:
+            return over[key]
+        if key in constants:
+            return constants[key]
+        raise KeyError(f"missing value for '{key}'")
+
+    return val
+
+
+def rule(name: str, condition: str, constraints: list, comment: str = "", layer: str = "") -> str:
+    lines = []
+    if comment:
+        lines.extend(f"# {c}" for c in comment.splitlines())
+    lines.append(f'(rule "{name}"')
+    if layer:
+        lines.append(f"\t(layer {layer})")
+    if condition:
+        lines.append(f'\t(condition "{condition}")')
+    lines.extend(f"\t{c}" for c in constraints)
+    lines.append(")")
+    return "\n".join(lines)
+
+
+def generate(fab: Fab, variant: dict) -> str:
+    p = fab.prefix
+    over = variant.get("over", {})
+    val = make_val(fab.constants, over)
+    layers = variant.get("layers", 2)
+    has_inner = layers > 2
+
+    out: list = []
+    out.append("(version 1)")
+    out.append(f"# Custom Design Rules (DRC) for KiCad — {fab.name}: {variant['label']}")
+    out.append("#")
+    out.append(f"# Matching {fab.name} capabilities: {fab.url}")
+    out.append("#")
+    out.append("# GENERATED FILE — do not edit by hand.")
+    out.append(f"# Edit capabilities/{fab.name}.toml and run tools/generate_dru.py instead.")
+    out.append("#")
+    out.append("# KiCad documentation: https://docs.kicad.org/8.0/en/pcbnew/pcbnew.html#custom-design-rules")
+
+    # --- Drill/Hole Size ---
+    out.append("\n\n# --- Drill/Hole Size ---\n")
+    out.append(rule(f"{p}: Drill Hole Size", "",
+                    [f"(constraint hole_size (min {val('drill_hole_min')}) (max {val('drill_hole_max')}))"]))
+    out.append("")
+    out.append(rule(f"{p}: Via Hole Size", "A.Type == 'Via'",
+                    [f"(constraint hole_size (min {val('via_hole')}))"]))
+    out.append("")
+    out.append(rule(f"{p}: Via Annular Ring", "A.Type == 'Via'",
+                    [f"(constraint annular_width (min {val('via_annular')}))"]))
+    out.append("")
+    out.append(rule(f"{p}: PTH Hole Size",
+                    "A.Type == 'Pad' && A.Pad_Type == 'Through-hole' && A.isPlated()",
+                    [f"(constraint hole_size (min {val('pth_hole_min')}) (max {val('pth_hole_max')}))"]))
+    out.append("")
+    out.append(rule(f"{p}: NPTH Hole Size",
+                    "A.Type == 'Pad' && A.Pad_Type == 'NPTH, mechanical' && !A.isPlated()",
+                    [f"(constraint hole_size (min {val('npth_hole_min')}))"]))
+    out.append("")
+    out.append(rule(f"{p}: Castellated Hole Size",
+                    "A.Type == 'Pad' && A.Fabrication_Property == 'Castellated pad'",
+                    [f"(constraint hole_size (min {val('castellated_min')}))"],
+                    layer="outer"))
+    out.append("")
+    out.append(rule(f"{p}: PTH Annular Ring",
+                    "A.Type == 'Pad' && A.Pad_Type == 'Through-hole' && A.isPlated()",
+                    [f"(constraint annular_width (min {val('pth_annular')}))"]))
+    out.append("")
+    out.append(rule(f"{p}: NPTH Annular Ring",
+                    "A.Type == 'Pad' && A.Pad_Type == 'NPTH, mechanical' && !A.isPlated()",
+                    [f"(constraint annular_width (min {val('npth_annular')}))"]))
+    if fab.flags.get("avoid_kelvin_test"):
+        out.append("")
+        out.append(rule(
+            f"{p}: Avoid 4-Wire Kelvin Test",
+            "(A.Type == 'Via' && A.Hole < 0.3mm && A.Diameter <= 0.4mm) || (A.Type == 'Pad' && ((A.Hole_Size_X < 0.3mm && A.Size_X <= 0.4mm) || (A.Hole_Size_Y < 0.3mm && A.Size_Y <= 0.4mm)))",
+            [f"(constraint annular_width (min {val('kelvin_annular')}))"],
+            comment="An expensive 4-Wire Kelvin Test is auto-added for holes < 0.3mm with diameter <= 0.4mm."))
+
+    # --- VIA Support Rules ---
+    if not fab.flags.get("allow_blind_buried"):
+        out.append("\n\n# --- VIA Support Rules ---\n")
+        out.append(rule(f"{p}: Only Throughhole VIAs are supported", "A.Type == 'Via'",
+                        ['(constraint assertion "!(A.isBlindBuriedVia() || A.isMicroVia())")']))
+
+    # --- Slot Width ---
+    out.append("\n\n# --- Slot Width ---\n")
+    out.append(rule(f"{p}: Plated Slot Width",
+                    "A.Type == 'Pad' && (A.Hole_Size_X != A.Hole_Size_Y) && A.isPlated()",
+                    [f"(constraint hole_size (min {val('plated_slot_min')}))"]))
+    out.append("")
+    out.append(rule(f"{p}: Non-Plated Slot Width",
+                    "A.Type == 'Pad' && (A.Hole_Size_X != A.Hole_Size_Y) && !A.isPlated()",
+                    [f"(constraint hole_size (min {val('nonplated_slot_min')}))"]))
+
+    # --- Minimum Clearance ---
+    out.append("\n\n# --- Minimum Clearance ---\n")
+    out.append(rule(f"{p}: Hole to Hole Clearance (Different Nets)", "A.Net != B.Net",
+                    [f"(constraint hole_to_hole (min {val('hole_to_hole_diff')}))"]))
+    out.append("")
+    out.append(rule(f"{p}: Via Hole to Via Hole Clearance (Same Net)",
+                    "A.Type == 'Via' && B.Type == 'Via' && A.Net == B.Net",
+                    [f"(constraint hole_to_hole (min {val('via_same_net')}))"]))
+    out.append("")
+    out.append(rule(f"{p}: Pad to Pad Clearance (Pad without Hole, Different Nets)",
+                    "A.Type == 'Pad' && (A.Pad_Type != 'Through-hole' && A.Pad_Type != 'NPTH, mechanical') && B.Type == 'Pad' && (B.Pad_Type != 'Through-hole' && B.Pad_Type != 'NPTH, mechanical') && A.Net != B.Net",
+                    [f"(constraint clearance (min {val('pad_nohole_diff')}))"]))
+    out.append("")
+    out.append(rule(f"{p}: Pad Hole to Pad Hole Clearance (Pad with Hole, Different Nets)",
+                    "A.Type == 'Pad' && (A.Pad_Type == 'Through-hole' || A.Pad_Type == 'NPTH, mechanical') && B.Type == 'Pad' && (B.Pad_Type == 'Through-hole' || B.Pad_Type == 'NPTH, mechanical') && A.Net != B.Net",
+                    [f"(constraint hole_to_hole (min {val('pad_hole_diff')}))"]))
+    if fab.flags.get("emit_implied_clearance"):
+        out.append("")
+        out.append(rule(f"{p}: Via/Pad to Via/Pad Clearance (Different Nets)",
+                        "(A.Type == 'Pad' || A.Type == 'Via') && (B.Type == 'Pad' || B.Type == 'Via') && A.Net != B.Net",
+                        [f"(constraint clearance (min {val('implied_diff')}))"],
+                        comment="Not stated specifically, but implied by other rules."))
+        out.append("")
+        out.append(rule(f"{p}: Via/Pad Hole to Via/Pad Hole Clearance (Same Net)",
+                        "(A.Type == 'Pad' || A.Type == 'Via') && (B.Type == 'Pad' || B.Type == 'Via') && A.Net == B.Net",
+                        [f"(constraint hole_to_hole (min {val('implied_same_net')}))"],
+                        comment="Not stated specifically, but implied by other rules."))
+    out.append("")
+    out.append(rule(f"{p}: Via to Trace", "A.Type == 'Via' && B.Type == 'Track'",
+                    [f"(constraint hole_clearance (min {val('via_to_trace')}))"]))
+    out.append("")
+    out.append(rule(f"{p}: PTH to Trace",
+                    "A.Type == 'Pad' && A.Pad_Type == 'Through-hole' && A.isPlated() && B.Type == 'Track'",
+                    [f"(constraint hole_clearance (min {val('pth_to_trace')}))"]))
+    out.append("")
+    out.append(rule(f"{p}: NPTH to Trace",
+                    "A.Type == 'Pad' && A.Pad_Type == 'NPTH, mechanical' && !A.isPlated() && B.Type == 'Track'",
+                    [f"(constraint hole_clearance (min {val('npth_to_trace')}))"]))
+    out.append("")
+    out.append(rule(f"{p}: NPTH to Copper (non-Track)",
+                    "A.Type == 'Pad' && A.Pad_Type == 'NPTH, mechanical' && !A.isPlated() && B.Type != 'Track'",
+                    [f"(constraint hole_clearance (min {val('npth_to_copper')}))"]))
+    out.append("")
+    out.append(rule(f"{p}: Pad to Trace",
+                    "A.Type == 'Pad' && (A.Pad_Type == 'Through-hole' || A.Pad_Type == 'NPTH, mechanical') && B.Type == 'Track' && A.Net != B.Net",
+                    [f"(constraint clearance (min {val('pad_to_trace')}))"]))
+    if fab.flags.get("emit_bga"):
+        out.append("")
+        out.append(rule(f"{p}: BGA to Trace",
+                        "A.NetClass == 'BGA' && B.Type == 'Track' && A.Net != B.Net",
+                        [f"(constraint clearance (min {val('bga_to_trace')}))"],
+                        comment="BGA fan-out clearance. Assign BGA fan-out nets to a 'BGA' net class."))
+
+    # --- Minimum Trace Width and Spacing ---
+    out.append("\n\n# --- Minimum Trace Width and Spacing ---\n")
+    out.append(rule(f"{p}: Trace Width (Outer Layer)", "A.Type == 'Track'",
+                    [f"(constraint track_width (min {val('trace_width_outer')}))"], layer="outer"))
+    out.append("")
+    out.append(rule(f"{p}: Trace Spacing (Outer Layer)", "A.Type == 'Track' && B.Type == 'Track'",
+                    [f"(constraint clearance (min {val('trace_spacing_outer')}))"], layer="outer"))
+    if has_inner:
+        out.append("")
+        out.append(rule(f"{p}: Trace Width (Inner Layer)", "A.Type == 'Track'",
+                        [f"(constraint track_width (min {val('trace_width_inner')}))"], layer="inner"))
+        out.append("")
+        out.append(rule(f"{p}: Trace Spacing (Inner Layer)", "A.Type == 'Track' && B.Type == 'Track'",
+                        [f"(constraint clearance (min {val('trace_spacing_inner')}))"], layer="inner"))
+
+    # --- Impedance-Controlled Net Classes ---
+    if fab.diffpairs:
+        out.append("\n\n# --- Impedance-Controlled Net Classes ---")
+        out.append("#")
+        out.append("# WARNING: trace width/gap for a target impedance depend on YOUR stackup")
+        out.append("# (dielectric height, Dk, copper weight). The values below are typical")
+        out.append(f"# starting points for {fab.name}'s default stackup — verify against")
+        out.append(f"# {fab.name}'s impedance calculator for your actual order. Constraints use")
+        out.append("# (opt ...) so they guide the router without raising nuisance DRC errors;")
+        out.append("# tighten to (min/max) once tuned. Assign nets to these classes in")
+        out.append("# Board Setup > Net Classes.\n")
+        for dp in fab.diffpairs:
+            if dp.get("diff"):
+                out.append(rule(f"{p}: {dp['name']} Differential Pair",
+                                f"A.NetClass == '{dp['name']}'",
+                                [f"(constraint track_width (opt {dp['track_width']}))",
+                                 f"(constraint diff_pair_gap (opt {dp['gap']}))"]))
+            else:
+                out.append(rule(f"{p}: {dp['name']} Single-Ended",
+                                f"A.NetClass == '{dp['name']}'",
+                                [f"(constraint track_width (opt {dp['track_width']}))"]))
+            out.append("")
+        out.pop()  # drop trailing blank
+
+    # --- Legend ---
+    out.append("\n\n# --- Legend ---\n")
+    out.append(rule(f"{p}: Minimum Line Width", "A.Type == 'Text' || A.Type == 'Text Box'",
+                    [f"(constraint text_thickness (min {val('text_thickness')}))"], layer='"?.Silkscreen"'))
+    out.append("")
+    out.append(rule(f"{p}: Minimum Text Height", "A.Type == 'Text' || A.Type == 'Text Box'",
+                    [f"(constraint text_height (min {val('text_height')}))"], layer='"?.Silkscreen"'))
+    out.append("")
+    out.append(rule(f"{p}: Pad to Silkscreen",
+                    "A.Type == 'Pad' && ((A.existsOnLayer('F.Mask') && B.Layer == 'F.Silkscreen') || (A.existsOnLayer('B.Mask') && B.Layer == 'B.Silkscreen'))",
+                    [f"(constraint silk_clearance (min {val('silk_clearance')}))"]))
+
+    # --- Board Outlines ---
+    out.append("\n\n# --- Board Outlines ---\n")
+    out.append(rule(f"{p}: Trace to Board Edge", "A.Type == 'Track'",
+                    [f"(constraint edge_clearance (min {val('edge_routed')}))"]))
+
+    return "\n".join(out) + "\n"
+
+
+def output_path(fab: Fab, variant: dict) -> str:
+    if variant["id"] == fab.default_variant:
+        fname = f"{fab.name}.kicad_dru"
+    else:
+        fname = f"{fab.name}-{variant['id']}.kicad_dru"
+    return os.path.join(ROOT, fab.name, fname)
+
+
+def main(argv: list) -> int:
+    check = "--check" in argv[1:]
+    toml_paths = sorted(glob.glob(os.path.join(ROOT, "capabilities", "*.toml")))
+    if not toml_paths:
+        print("no capabilities/*.toml files found", file=sys.stderr)
+        return 1
+
+    stale = []
+    written = []
+    for tp in toml_paths:
+        with open(tp, "rb") as fh:
+            fab = Fab(tomllib.load(fh))
+        for variant in fab.variants:
+            text = generate(fab, variant)
+            path = output_path(fab, variant)
+            existing = None
+            if os.path.exists(path):
+                with open(path, "r", encoding="utf-8") as fh:
+                    existing = fh.read()
+            if check:
+                if existing != text:
+                    stale.append(os.path.relpath(path, ROOT))
+            else:
+                os.makedirs(os.path.dirname(path), exist_ok=True)
+                with open(path, "w", encoding="utf-8") as fh:
+                    fh.write(text)
+                written.append(os.path.relpath(path, ROOT))
+
+    if check:
+        if stale:
+            print("Generated files are out of date; run tools/generate_dru.py:", file=sys.stderr)
+            for s in stale:
+                print(f"  {s}", file=sys.stderr)
+            return 1
+        print("All generated files are up to date.")
+        return 0
+
+    for w in written:
+        print(f"wrote {w}")
+    print(f"\n{len(written)} file(s) generated.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tools/lint_dru.py
+++ b/tools/lint_dru.py
@@ -138,11 +138,13 @@ def lint_file(path: str) -> list:
     if not forms or not re.match(r"\(\s*version\s+1\s*\)", forms[0][1]):
         errors.append((1, "file must start with a `(version 1)` header"))
 
-    # 2. fab prefix from filename, e.g. JLCPCB.kicad_dru or
-    #    JLCPCB-4L-1oz.kicad_dru -> "JLCPCB: " (part before the first '-')
-    fab = os.path.basename(path).split(".")[0].split("-")[0]
-
+    # 2. Rule names must share one "<FAB>: " prefix, and the filename must start
+    #    with it. Deriving the prefix from the rules (not by splitting the
+    #    filename on '-') keeps this correct for hyphenated fab names and for
+    #    variant files like JLCPCB-4L-1oz.kicad_dru.
+    stem = os.path.basename(path).split(".")[0]
     seen_names: dict = {}
+    prefixes: dict = {}  # prefix -> first line seen
     for start_line, form in forms:
         if not re.match(r"\(\s*rule\b", form):
             continue
@@ -163,10 +165,17 @@ def lint_file(path: str) -> list:
         else:
             seen_names[name] = start_line
 
-        if not name.startswith(f"{fab}: "):
+        if ": " in name:
+            prefixes.setdefault(name.split(": ", 1)[0], start_line)
+        else:
+            errors.append((start_line, f'rule "{name}" should be named "<FAB>: ..."'))
+
+    if len(prefixes) > 1:
+        errors.append((1, f"rules use more than one fab prefix: {sorted(prefixes)}"))
+    for pfx in prefixes:
+        if not stem.startswith(pfx):
             errors.append(
-                (start_line, f'rule "{name}" should be prefixed with "{fab}: "')
-            )
+                (prefixes[pfx], f'rule prefix "{pfx}" does not match filename "{stem}"'))
 
     # 3. lowercase type literals (scanned on the raw text so line numbers and
     #    the surrounding condition are reported as the author wrote them).

--- a/tools/lint_dru.py
+++ b/tools/lint_dru.py
@@ -138,8 +138,9 @@ def lint_file(path: str) -> list:
     if not forms or not re.match(r"\(\s*version\s+1\s*\)", forms[0][1]):
         errors.append((1, "file must start with a `(version 1)` header"))
 
-    # 2. fab prefix from filename, e.g. JLCPCB.kicad_dru -> "JLCPCB: "
-    fab = os.path.basename(path).split(".")[0]
+    # 2. fab prefix from filename, e.g. JLCPCB.kicad_dru or
+    #    JLCPCB-4L-1oz.kicad_dru -> "JLCPCB: " (part before the first '-')
+    fab = os.path.basename(path).split(".")[0].split("-")[0]
 
     seen_names: dict = {}
     for start_line, form in forms:

--- a/tools/test_tools.py
+++ b/tools/test_tools.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Tests for the design-rule tooling. No dependencies — run directly:
+
+    python3 tools/test_tools.py
+
+Exits non-zero on the first failure.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+
+import generate_dru as g  # noqa: E402
+import lint_dru as lint  # noqa: E402
+
+PASSED = 0
+
+
+def check(cond, msg):
+    global PASSED
+    if not cond:
+        print(f"FAIL: {msg}", file=sys.stderr)
+        raise SystemExit(1)
+    PASSED += 1
+
+
+def lint_text(text: str, name: str = "JLCPCB.kicad_dru"):
+    with tempfile.TemporaryDirectory() as d:
+        p = os.path.join(d, name)
+        with open(p, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        return lint.lint_file(p)
+
+
+# --- linter: happy path ---
+GOOD = (
+    '(version 1)\n'
+    '(rule "JLCPCB: Trace Width"\n'
+    '\t(condition "A.Type == \'Track\'")\n'
+    '\t(constraint track_width (min 0.09mm))\n)\n'
+)
+check(lint_text(GOOD) == [], "clean file should have no lint errors")
+
+# --- linter: lowercase type literal ---
+bad = GOOD.replace("'Track'", "'track'")
+check(any("lowercase type literal" in m for _, m in lint_text(bad)),
+      "lowercase 'track' should be flagged")
+
+# --- linter: missing constraint ---
+nocon = '(version 1)\n(rule "JLCPCB: X"\n\t(condition "A.Type == \'Via\'")\n)\n'
+check(any("no (constraint" in m for _, m in lint_text(nocon)),
+      "rule without a constraint should be flagged")
+
+# --- linter: duplicate rule name ---
+dup = GOOD + GOOD.split("\n", 1)[1]  # append the rule again (no second version line)
+check(any("duplicate rule name" in m for _, m in lint_text(dup)),
+      "duplicate rule name should be flagged")
+
+# --- linter: unbalanced parens ---
+check(any("unbalanced" in m for _, m in lint_text(GOOD[:-3])),
+      "unbalanced parens should be flagged")
+
+# --- linter: prefix must match filename (and tolerate hyphenated fab names) ---
+check(any("does not match filename" in m for _, m in lint_text(GOOD, "PCBWay.kicad_dru")),
+      "JLCPCB-prefixed rules in a PCBWay file should be flagged")
+check(lint_text(GOOD, "JLCPCB-4L-2oz.kicad_dru") == [],
+      "variant filename should accept the base fab prefix")
+hyph = GOOD.replace("JLCPCB:", "Sierra-Circuits:")
+check(lint_text(hyph, "Sierra-Circuits.kicad_dru") == [],
+      "hyphenated fab name should not be falsely flagged")
+
+# --- generator: validate() rejects bad config ---
+BASE = {
+    "fab": {"name": "X", "prefix": "X", "capabilities_url": "u", "default_variant": "a"},
+    "flags": {}, "constants": {}, "variant": [{"id": "a", "layers": 2}], "diffpair": [],
+}
+
+
+def clone(**over):
+    import copy
+    d = copy.deepcopy(BASE)
+    for k, v in over.items():
+        d[k] = v
+    return d
+
+
+def rejects(data, needle):
+    try:
+        g.validate(g.Fab(data))
+    except ValueError as e:
+        check(needle in str(e), f"expected '{needle}' in: {e}")
+        return
+    check(False, f"validate should have rejected config for '{needle}'")
+
+
+g.validate(g.Fab(BASE))  # baseline is valid
+PASSED += 1
+rejects(clone(fab={**BASE["fab"], "default_variant": "nope"}), "default_variant")
+rejects(clone(variant=[]), "no [[variant]]")
+rejects(clone(flags={"emit_bga": True}), "bga_to_trace")
+rejects(clone(diffpair=[{"name": "100R_Diff", "diff": True, "track_width": "0.2mm"}]), "gap")
+
+# --- generator: round-trip — every generated file lints clean and balances parens ---
+import glob  # noqa: E402
+for tp in glob.glob(os.path.join(g.ROOT, "capabilities", "*.toml")):
+    import tomllib
+    with open(tp, "rb") as fh:
+        fab = g.Fab(tomllib.load(fh))
+    g.validate(fab)
+    for v in fab.variants:
+        text = g.generate(fab, v)
+        errs = []
+        check(lint.check_paren_balance(text, errs), f"{fab.name} {v['id']}: balanced parens")
+        # 2-layer variants must not emit inner-layer trace rules
+        if v.get("layers", 2) <= 2:
+            check("Inner Layer" not in text, f"{fab.name} {v['id']}: no inner-layer rules on 2L")
+
+print(f"OK — {PASSED} checks passed")


### PR DESCRIPTION
The overhaul we scoped: move from hand-maintained `.kicad_dru` files to files **generated** from a single source of truth per fab. See `DESIGN.md` for the full rationale.

## What changed

- **Source of truth:** `capabilities/JLCPCB.toml`, `capabilities/PCBWay.toml` — every value + fab metadata + variant overrides + feature flags, seeded from the previously committed rules (no value changes to the standard variant).
- **Generator:** `tools/generate_dru.py` (dependency-free, stdlib `tomllib`) emits one `.kicad_dru` per variant. The default variant keeps the plain `<FAB>.kicad_dru` name; others get `<FAB>-<id>.kicad_dru`. `--check` fails if committed output drifts from the TOML.
- **Legacy files fully replaced** — the "Choose between / uncomment the right variant" comment blocks are gone. Each variant is now its own concrete, independently-lintable file.
- **Matrix (focused, ~4/fab):** `2L-1oz`, `4L-1oz` (default), `4L-2oz`, `6L-1oz`.
- **Impedance-controlled net classes** baked into every file: `50R` (single-ended) and `60R_Diff` / `90R_Diff` / `100R_Diff` / `120R_Diff`. Values are typical starting points for each fab's default stackup, using `(opt …)` so they guide the router without nuisance DRC errors, with a loud stackup-dependency warning in-file and in the README.
- **CI:** the lint workflow now runs `generate_dru.py --check` (in-sync) before `lint_dru.py`.

## Behaviour vs today

The generated default files are **rule-for-rule equivalent** to the previous hand-maintained files, except:
- commented-out alternates are removed (that's the point — pick the matching file instead);
- the additive impedance net classes;
- **JLCPCB gains `NPTH to Copper (non-Track)`** — #31's commit message listed this rule but it never actually landed in the file (PCBWay got it in #29). The generator emits it for both fabs now, closing that gap.

## Follow-ups (not in this PR)

- Refine diff-pair and per-variant values from the fabs' controlled-impedance / capability tables once reachable (egress-blocked in CI today).
- Auto-generated fab comparison matrix doc; optional `kicad-cli pcb drc` golden tests; widen the variant matrix.

Every generated file passes both the linter and the in-sync check.

---
_Generated by [Claude Code](https://claude.ai/code/session_018nCM3QGQaHyfzBwAJz91fs)_