### PR TITLE
Use file-format layer names for silkscreen rules, and lint for it

### DIFF
--- a/JLCPCB/JLCPCB.kicad_dru
+++ b/JLCPCB/JLCPCB.kicad_dru
@@ -213,19 +213,19 @@
 # --- Legend ---
 
 (rule "JLCPCB: Minimum Line Width"
-	(layer "?.Silkscreen")
+	(layer "?.SilkS")
 	(condition "A.Type == 'Text' || A.Type == 'Text Box'")
 	(constraint text_thickness (min 0.15mm))
 )
 
 (rule "JLCPCB: Minimum Text Height"
-	(layer "?.Silkscreen")
+	(layer "?.SilkS")
 	(condition "A.Type == 'Text' || A.Type == 'Text Box'")
 	(constraint text_height (min 1mm))
 )
 
 (rule "JLCPCB: Pad to Silkscreen"
-	(condition "A.Type == 'Pad' && ((A.existsOnLayer('F.Mask') && B.Layer == 'F.Silkscreen') || (A.existsOnLayer('B.Mask') && B.Layer == 'B.Silkscreen')) ")
+	(condition "A.Type == 'Pad' && ((A.existsOnLayer('F.Mask') && B.Layer == 'F.SilkS') || (A.existsOnLayer('B.Mask') && B.Layer == 'B.SilkS')) ")
 	(constraint silk_clearance (min 0.15mm))
 )
 

--- a/PCBWay/PCBWay.kicad_dru
+++ b/PCBWay/PCBWay.kicad_dru
@@ -170,19 +170,19 @@
 # --- Legend ---
 
 (rule "PCBWay: Minimum Line Width"
-	(layer "?.Silkscreen")
+	(layer "?.SilkS")
 	(condition "A.Type == 'Text' || A.Type == 'Text Box'")
 	(constraint text_thickness (min 0.15mm))
 )
 
 (rule "PCBWay: Minimum Text Height"
-	(layer "?.Silkscreen")
+	(layer "?.SilkS")
 	(condition "A.Type == 'Text' || A.Type == 'Text Box'")
 	(constraint text_height (min 0.8mm))
 )
 
 (rule "PCBWay: Pad to Silkscreen"
-	(condition "A.Type == 'Pad' && ((A.existsOnLayer('F.Mask') && B.Layer == 'F.Silkscreen') || (A.existsOnLayer('B.Mask') && B.Layer == 'B.Silkscreen'))")
+	(condition "A.Type == 'Pad' && ((A.existsOnLayer('F.Mask') && B.Layer == 'F.SilkS') || (A.existsOnLayer('B.Mask') && B.Layer == 'B.SilkS'))")
 	(constraint silk_clearance (min 0.15mm))
 )
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,15 @@ Each folder contains:
 
 Many rules have alternates commented out for different layer counts or copper weights. Read the comments at the top of each rule and uncomment the variant that matches what you're ordering.
 
+## Layer names
+
+Rules here use KiCad's file-format layer names — `F.SilkS`, not `F.Silkscreen`. Both spellings resolve on a board that still uses KiCad's default layer names, but the display name is editable in Board Setup, and board importers (Altium, Eagle, EasyEDA, CADSTAR) overwrite it with the source tool's naming. Boards written before KiCad 6 also load with the file-format name showing. On any of those, a rule written against the display name silently stops matching.
+
+That failure is worse than it looks. An unresolvable layer name in a `(layer ...)` clause makes KiCad reject the **entire** rule file, so every rule in it stops being enforced — not just the offending one. The PCB editor shows an `Unrecognized layer` error, but `kicad-cli pcb drc` reports nothing: no message, empty stderr, exit code 0. A green DRC run in CI does not prove your custom rules ran. After adding a `.kicad_dru`, check `Board Setup > Design Rules > Custom Rules` for errors.
+
 ## Validation
 
-Every `.kicad_dru` file is checked in CI by a small linter (`tools/lint_dru.py`, no dependencies) that catches malformed s-expressions, missing `(version 1)` headers, rules with no constraint, duplicate names, wrong fab prefixes, and lowercase item-type literals (`'track'`/`'via'`/`'pad'`) that KiCad silently never matches. Run it locally with:
+Every `.kicad_dru` file is checked in CI by a small linter (`tools/lint_dru.py`, no dependencies) that catches malformed s-expressions, missing `(version 1)` headers, rules with no constraint, duplicate names, wrong fab prefixes, lowercase item-type literals (`'track'`/`'via'`/`'pad'`) that KiCad silently never matches, and layer names written in their display form (`F.Silkscreen` instead of `F.SilkS`) or matching no layer at all. Run it locally with:
 
 ```
 python3 tools/lint_dru.py

--- a/tools/lint_dru.py
+++ b/tools/lint_dru.py
@@ -12,6 +12,13 @@ before there was any automated check:
   * lowercase item-type literals in conditions (`'track'`, `'via'`, `'pad'`,
     `'text'`, `'graphic'`) — KiCad expects PascalCase (`'Track'`, `'Via'`,
     `'Pad'`, ...); the lowercase form parses fine but silently never matches.
+  * layer names written in their Board Setup display form (`F.Silkscreen`)
+    rather than the file-format form (`F.SilkS`), and layer names matching no
+    KiCad layer at all. A display name resolves only while the board still
+    uses the default: imported boards and boards written before KiCad 6 carry
+    a different name, and the rule then stops matching. In a `(layer ...)`
+    clause that makes KiCad reject the whole file, so every rule in it quietly
+    stops being enforced; in a condition it fails with no message anywhere.
 
 No third-party dependencies; runs on any Python 3.8+.
 
@@ -24,6 +31,7 @@ Exit code is non-zero if any error is found.
 
 from __future__ import annotations
 
+import fnmatch
 import glob
 import os
 import re
@@ -42,6 +50,78 @@ BAD_TYPE_LITERALS = {
 
 # Matches e.g.  A.Type == 'track'   or   B.Type=='via'
 TYPE_LITERAL_RE = re.compile(r"\.Type\s*[=!]=\s*'([^']*)'")
+
+# The layer names KiCad writes in board files. These never change and are the
+# only spellings that resolve on every board.
+KNOWN_LAYERS = {
+    "F.Cu", "B.Cu",
+    "F.Adhes", "B.Adhes",
+    "F.Paste", "B.Paste",
+    "F.SilkS", "B.SilkS",
+    "F.Mask", "B.Mask",
+    "F.CrtYd", "B.CrtYd",
+    "F.Fab", "B.Fab",
+    "Edge.Cuts", "Margin",
+    "Dwgs.User", "Cmts.User", "Eco1.User", "Eco2.User",
+}
+KNOWN_LAYERS.update(f"In{n}.Cu" for n in range(1, 31))
+KNOWN_LAYERS.update(f"User.{n}" for n in range(1, 46))
+
+# Board Setup display names whose file-format spelling differs. The display
+# name is editable, and board importers overwrite it, so a rule written
+# against it stops matching. Suffix map first (these pair with an F./B./? or
+# a glob prefix), then the handful of whole names that differ.
+DISPLAY_SUFFIXES = {
+    "Silkscreen": "SilkS",
+    "Courtyard": "CrtYd",
+    "Adhesive": "Adhes",
+}
+DISPLAY_NAMES = {
+    "User.Drawings": "Dwgs.User",
+    "User.Comments": "Cmts.User",
+    "User.Eco1": "Eco1.User",
+    "User.Eco2": "Eco2.User",
+}
+
+# Layer keywords that are not layer names.
+LAYER_KEYWORDS = {"outer", "inner"}
+
+# Where a layer name can appear: a (layer "...") clause, a .Layer comparison,
+# or an existsOnLayer('...') call.
+LAYER_CLAUSE_RE = re.compile(r'\(\s*layer\s+"([^"]*)"')
+LAYER_COMPARE_RE = re.compile(r"\.Layer\s*[=!]=\s*'([^']*)'")
+EXISTS_ON_LAYER_RE = re.compile(r"existsOnLayer\(\s*'([^']*)'\s*\)")
+
+
+def check_layer_token(token: str):
+    """Return an error message for one layer name, or None if it is fine.
+
+    Handles KiCad's `?` (one character) and `*` (any run) wildcards, which is
+    how `?.SilkS` covers both the front and back layers.
+    """
+    if token in LAYER_KEYWORDS:
+        return None
+
+    if any(fnmatch.fnmatchcase(known, token) for known in KNOWN_LAYERS):
+        return None
+
+    # Resolves against no board layer. Say why, if we can tell.
+    if token in DISPLAY_NAMES:
+        return (
+            f"layer '{token}' is a Board Setup display name — use the "
+            f"file-format name '{DISPLAY_NAMES[token]}'"
+        )
+
+    prefix, _, suffix = token.rpartition(".")
+    if suffix in DISPLAY_SUFFIXES:
+        return (
+            f"layer '{token}' is a Board Setup display name — use the "
+            f"file-format name '{prefix}.{DISPLAY_SUFFIXES[suffix]}'. The "
+            f"display name is editable and board importers rewrite it, so "
+            f"this only matches while the board keeps KiCad's default"
+        )
+
+    return f"layer '{token}' matches no KiCad layer"
 
 
 class LintError(Exception):
@@ -181,6 +261,16 @@ def lint_file(path: str) -> list:
                         f"'{BAD_TYPE_LITERALS[literal]}' (the lowercase form never matches)",
                     )
                 )
+
+    # 4. layer names, in (layer ...) clauses, .Layer comparisons and
+    #    existsOnLayer() calls.
+    for i, raw_line in enumerate(raw.splitlines(), start=1):
+        line_code = strip_comments(raw_line)
+        for pattern in (LAYER_CLAUSE_RE, LAYER_COMPARE_RE, EXISTS_ON_LAYER_RE):
+            for m in pattern.finditer(line_code):
+                problem = check_layer_token(m.group(1))
+                if problem:
+                    errors.append((i, problem))
 
     return errors
 


### PR DESCRIPTION
Two users hit `ERROR: Unrecognized layer '?.Silkscreen'` when adding these rules to their projects (#33, and the same report upstream). They were right, and the problem is bigger than the error suggests.

## What was wrong

The silkscreen rules used `?.Silkscreen` and `F./B.Silkscreen`. Those are Board Setup **display names**. A layer name in a `.kicad_dru` resolves against the file-format name (`F.SilkS`, always present) plus the board's current layer name — and the current name only equals `F.Silkscreen` while the board keeps KiCad's default.

Two ways a board carries a different name with no user action:

- Board importers — Altium, Eagle, EasyEDA, CADSTAR, Fabmaster, legacy — write the source tool's layer names in. Altium boards arrive as `Top Overlay`.
- Any `.kicad_pcb` older than file version 20200922 (KiCad 5.1 and earlier) loads with the layer named `F.SilkS`, and looks untouched in Board Setup.

On those boards the name does not resolve, and KiCad rejects the **entire rule file** — every JLCPCB or PCBWay rule silently reverts to KiCad defaults.

## What changed

**Rule files.** Both surfaces, in both fabs. The `(layer ...)` clauses that produce the visible error, and the `Pad to Silkscreen` conditions that fail with no message at all (#34) — fixing only the first would have left that rule dead.

**Linter.** It had no layer vocabulary and passed both files despite this bug (#35). It now checks every layer name in a `(layer ...)` clause, a `.Layer` comparison and an `existsOnLayer()` call, handling the `?`/`*` wildcards and the `outer`/`inner` keywords. Display-name spellings get a message naming the file-format form to use; anything matching no layer is reported as unknown.

**README.** Short section on why the file-format names matter, plus the warning that `kicad-cli pcb drc` reports a rejected rule file as a clean run with exit code 0 — so green CI does not prove the rules ran.

## Evidence

Run against the paired test boards on KiCad 9.0.6 and 10.0.5. Thresholds exaggerated so a live rule must fire; baseline with no custom rules is 30 violations.

| Board | Spelling | 9.0.6 | 10.0.5 | |
|---|---|---|---|---|
| stock | `?.Silkscreen` | 51 | 51 | fires |
| stock | `?.SilkS` | 51 | 51 | fires |
| silk layers renamed | `?.Silkscreen` + a good rule | 30 | 30 | whole file discarded |
| silk layers renamed | `?.SilkS` + a good rule | 72 | 72 | both fire |
| silk layers renamed | condition `== 'F.Silkscreen'` | 0 | 0 | silently inert |
| silk layers renamed | condition `== 'F.SilkS'` | 26 | 26 | fires |

Linter checked both ways: it passes the fixed files, and flags all four occurrences in the pre-fix content with the right suggestion.

Not a version regression — the layer names are identical in KiCad 7, 8, 9, 10 and master, and 9.0.4 and 9.0.6 are byte-identical in the files that matter. The README claim about tokens being unchanged across 8/9/10 still holds and is left alone.

#32 carries the same spelling in its generator and emits it into all eight generated files; that needs the same change on its branch.

Refs #33
Refs #34
Refs #35
