### PR TITLE
Emit file-format silkscreen layer names from the generator

### DIFF
--- a/JLCPCB/JLCPCB-2L-1oz.kicad_dru
+++ b/JLCPCB/JLCPCB-2L-1oz.kicad_dru
@@ -206,19 +206,19 @@
 # --- Legend ---
 
 (rule "JLCPCB: Minimum Line Width"
-	(layer "?.Silkscreen")
+	(layer "?.SilkS")
 	(condition "A.Type == 'Text' || A.Type == 'Text Box'")
 	(constraint text_thickness (min 0.15mm))
 )
 
 (rule "JLCPCB: Minimum Text Height"
-	(layer "?.Silkscreen")
+	(layer "?.SilkS")
 	(condition "A.Type == 'Text' || A.Type == 'Text Box'")
 	(constraint text_height (min 1mm))
 )
 
 (rule "JLCPCB: Pad to Silkscreen"
-	(condition "A.Type == 'Pad' && ((A.existsOnLayer('F.Mask') && B.Layer == 'F.Silkscreen') || (A.existsOnLayer('B.Mask') && B.Layer == 'B.Silkscreen'))")
+	(condition "A.Type == 'Pad' && ((A.existsOnLayer('F.Mask') && B.Layer == 'F.SilkS') || (A.existsOnLayer('B.Mask') && B.Layer == 'B.SilkS'))")
 	(constraint silk_clearance (min 0.15mm))
 )
 

--- a/JLCPCB/JLCPCB-4L-2oz.kicad_dru
+++ b/JLCPCB/JLCPCB-4L-2oz.kicad_dru
@@ -218,19 +218,19 @@
 # --- Legend ---
 
 (rule "JLCPCB: Minimum Line Width"
-	(layer "?.Silkscreen")
+	(layer "?.SilkS")
 	(condition "A.Type == 'Text' || A.Type == 'Text Box'")
 	(constraint text_thickness (min 0.15mm))
 )
 
 (rule "JLCPCB: Minimum Text Height"
-	(layer "?.Silkscreen")
+	(layer "?.SilkS")
 	(condition "A.Type == 'Text' || A.Type == 'Text Box'")
 	(constraint text_height (min 1mm))
 )
 
 (rule "JLCPCB: Pad to Silkscreen"
-	(condition "A.Type == 'Pad' && ((A.existsOnLayer('F.Mask') && B.Layer == 'F.Silkscreen') || (A.existsOnLayer('B.Mask') && B.Layer == 'B.Silkscreen'))")
+	(condition "A.Type == 'Pad' && ((A.existsOnLayer('F.Mask') && B.Layer == 'F.SilkS') || (A.existsOnLayer('B.Mask') && B.Layer == 'B.SilkS'))")
 	(constraint silk_clearance (min 0.15mm))
 )
 

--- a/JLCPCB/JLCPCB-6L-1oz.kicad_dru
+++ b/JLCPCB/JLCPCB-6L-1oz.kicad_dru
@@ -218,19 +218,19 @@
 # --- Legend ---
 
 (rule "JLCPCB: Minimum Line Width"
-	(layer "?.Silkscreen")
+	(layer "?.SilkS")
 	(condition "A.Type == 'Text' || A.Type == 'Text Box'")
 	(constraint text_thickness (min 0.15mm))
 )
 
 (rule "JLCPCB: Minimum Text Height"
-	(layer "?.Silkscreen")
+	(layer "?.SilkS")
 	(condition "A.Type == 'Text' || A.Type == 'Text Box'")
 	(constraint text_height (min 1mm))
 )
 
 (rule "JLCPCB: Pad to Silkscreen"
-	(condition "A.Type == 'Pad' && ((A.existsOnLayer('F.Mask') && B.Layer == 'F.Silkscreen') || (A.existsOnLayer('B.Mask') && B.Layer == 'B.Silkscreen'))")
+	(condition "A.Type == 'Pad' && ((A.existsOnLayer('F.Mask') && B.Layer == 'F.SilkS') || (A.existsOnLayer('B.Mask') && B.Layer == 'B.SilkS'))")
 	(constraint silk_clearance (min 0.15mm))
 )
 

--- a/JLCPCB/JLCPCB.kicad_dru
+++ b/JLCPCB/JLCPCB.kicad_dru
@@ -218,19 +218,19 @@
 # --- Legend ---
 
 (rule "JLCPCB: Minimum Line Width"
-	(layer "?.Silkscreen")
+	(layer "?.SilkS")
 	(condition "A.Type == 'Text' || A.Type == 'Text Box'")
 	(constraint text_thickness (min 0.15mm))
 )
 
 (rule "JLCPCB: Minimum Text Height"
-	(layer "?.Silkscreen")
+	(layer "?.SilkS")
 	(condition "A.Type == 'Text' || A.Type == 'Text Box'")
 	(constraint text_height (min 1mm))
 )
 
 (rule "JLCPCB: Pad to Silkscreen"
-	(condition "A.Type == 'Pad' && ((A.existsOnLayer('F.Mask') && B.Layer == 'F.Silkscreen') || (A.existsOnLayer('B.Mask') && B.Layer == 'B.Silkscreen'))")
+	(condition "A.Type == 'Pad' && ((A.existsOnLayer('F.Mask') && B.Layer == 'F.SilkS') || (A.existsOnLayer('B.Mask') && B.Layer == 'B.SilkS'))")
 	(constraint silk_clearance (min 0.15mm))
 )
 

--- a/PCBWay/PCBWay-2L-1oz.kicad_dru
+++ b/PCBWay/PCBWay-2L-1oz.kicad_dru
@@ -174,19 +174,19 @@
 # --- Legend ---
 
 (rule "PCBWay: Minimum Line Width"
-	(layer "?.Silkscreen")
+	(layer "?.SilkS")
 	(condition "A.Type == 'Text' || A.Type == 'Text Box'")
 	(constraint text_thickness (min 0.15mm))
 )
 
 (rule "PCBWay: Minimum Text Height"
-	(layer "?.Silkscreen")
+	(layer "?.SilkS")
 	(condition "A.Type == 'Text' || A.Type == 'Text Box'")
 	(constraint text_height (min 0.8mm))
 )
 
 (rule "PCBWay: Pad to Silkscreen"
-	(condition "A.Type == 'Pad' && ((A.existsOnLayer('F.Mask') && B.Layer == 'F.Silkscreen') || (A.existsOnLayer('B.Mask') && B.Layer == 'B.Silkscreen'))")
+	(condition "A.Type == 'Pad' && ((A.existsOnLayer('F.Mask') && B.Layer == 'F.SilkS') || (A.existsOnLayer('B.Mask') && B.Layer == 'B.SilkS'))")
 	(constraint silk_clearance (min 0.15mm))
 )
 

--- a/PCBWay/PCBWay-4L-2oz.kicad_dru
+++ b/PCBWay/PCBWay-4L-2oz.kicad_dru
@@ -186,19 +186,19 @@
 # --- Legend ---
 
 (rule "PCBWay: Minimum Line Width"
-	(layer "?.Silkscreen")
+	(layer "?.SilkS")
 	(condition "A.Type == 'Text' || A.Type == 'Text Box'")
 	(constraint text_thickness (min 0.15mm))
 )
 
 (rule "PCBWay: Minimum Text Height"
-	(layer "?.Silkscreen")
+	(layer "?.SilkS")
 	(condition "A.Type == 'Text' || A.Type == 'Text Box'")
 	(constraint text_height (min 0.8mm))
 )
 
 (rule "PCBWay: Pad to Silkscreen"
-	(condition "A.Type == 'Pad' && ((A.existsOnLayer('F.Mask') && B.Layer == 'F.Silkscreen') || (A.existsOnLayer('B.Mask') && B.Layer == 'B.Silkscreen'))")
+	(condition "A.Type == 'Pad' && ((A.existsOnLayer('F.Mask') && B.Layer == 'F.SilkS') || (A.existsOnLayer('B.Mask') && B.Layer == 'B.SilkS'))")
 	(constraint silk_clearance (min 0.15mm))
 )
 

--- a/PCBWay/PCBWay-6L-1oz.kicad_dru
+++ b/PCBWay/PCBWay-6L-1oz.kicad_dru
@@ -186,19 +186,19 @@
 # --- Legend ---
 
 (rule "PCBWay: Minimum Line Width"
-	(layer "?.Silkscreen")
+	(layer "?.SilkS")
 	(condition "A.Type == 'Text' || A.Type == 'Text Box'")
 	(constraint text_thickness (min 0.15mm))
 )
 
 (rule "PCBWay: Minimum Text Height"
-	(layer "?.Silkscreen")
+	(layer "?.SilkS")
 	(condition "A.Type == 'Text' || A.Type == 'Text Box'")
 	(constraint text_height (min 0.8mm))
 )
 
 (rule "PCBWay: Pad to Silkscreen"
-	(condition "A.Type == 'Pad' && ((A.existsOnLayer('F.Mask') && B.Layer == 'F.Silkscreen') || (A.existsOnLayer('B.Mask') && B.Layer == 'B.Silkscreen'))")
+	(condition "A.Type == 'Pad' && ((A.existsOnLayer('F.Mask') && B.Layer == 'F.SilkS') || (A.existsOnLayer('B.Mask') && B.Layer == 'B.SilkS'))")
 	(constraint silk_clearance (min 0.15mm))
 )
 

--- a/PCBWay/PCBWay.kicad_dru
+++ b/PCBWay/PCBWay.kicad_dru
@@ -186,19 +186,19 @@
 # --- Legend ---
 
 (rule "PCBWay: Minimum Line Width"
-	(layer "?.Silkscreen")
+	(layer "?.SilkS")
 	(condition "A.Type == 'Text' || A.Type == 'Text Box'")
 	(constraint text_thickness (min 0.15mm))
 )
 
 (rule "PCBWay: Minimum Text Height"
-	(layer "?.Silkscreen")
+	(layer "?.SilkS")
 	(condition "A.Type == 'Text' || A.Type == 'Text Box'")
 	(constraint text_height (min 0.8mm))
 )
 
 (rule "PCBWay: Pad to Silkscreen"
-	(condition "A.Type == 'Pad' && ((A.existsOnLayer('F.Mask') && B.Layer == 'F.Silkscreen') || (A.existsOnLayer('B.Mask') && B.Layer == 'B.Silkscreen'))")
+	(condition "A.Type == 'Pad' && ((A.existsOnLayer('F.Mask') && B.Layer == 'F.SilkS') || (A.existsOnLayer('B.Mask') && B.Layer == 'B.SilkS'))")
 	(constraint silk_clearance (min 0.15mm))
 )
 

--- a/tools/generate_dru.py
+++ b/tools/generate_dru.py
@@ -278,13 +278,13 @@ def generate(fab: Fab, variant: dict) -> str:
     # --- Legend ---
     out.append("\n\n# --- Legend ---\n")
     out.append(rule(f"{p}: Minimum Line Width", "A.Type == 'Text' || A.Type == 'Text Box'",
-                    [f"(constraint text_thickness (min {val('text_thickness')}))"], layer='"?.Silkscreen"'))
+                    [f"(constraint text_thickness (min {val('text_thickness')}))"], layer='"?.SilkS"'))
     out.append("")
     out.append(rule(f"{p}: Minimum Text Height", "A.Type == 'Text' || A.Type == 'Text Box'",
-                    [f"(constraint text_height (min {val('text_height')}))"], layer='"?.Silkscreen"'))
+                    [f"(constraint text_height (min {val('text_height')}))"], layer='"?.SilkS"'))
     out.append("")
     out.append(rule(f"{p}: Pad to Silkscreen",
-                    "A.Type == 'Pad' && ((A.existsOnLayer('F.Mask') && B.Layer == 'F.Silkscreen') || (A.existsOnLayer('B.Mask') && B.Layer == 'B.Silkscreen'))",
+                    "A.Type == 'Pad' && ((A.existsOnLayer('F.Mask') && B.Layer == 'F.SilkS') || (A.existsOnLayer('B.Mask') && B.Layer == 'B.SilkS'))",
                     [f"(constraint silk_clearance (min {val('silk_clearance')}))"]))
 
     # --- Board Outlines ---


### PR DESCRIPTION
Applies the #33 fix to the generator, so this branch stops carrying the bug into the files it emits.

## What was wrong

`tools/generate_dru.py` hard-coded `?.Silkscreen` in the two Legend layer clauses and `F./B.Silkscreen` in the Pad to Silkscreen condition, so all eight generated `.kicad_dru` files shipped both faults.

Those are Board Setup display names. A `.kicad_dru` layer name resolves against the file-format name (`F.SilkS`, always present) plus the board's current layer name, which equals `F.Silkscreen` only while the board keeps KiCad's default. Board importers — Altium, Eagle, EasyEDA, CADSTAR, Fabmaster — write the source tool's naming in, and any `.kicad_pcb` older than file version 20200922 (KiCad 5.1 and earlier) loads with the file-format name showing. On those boards the name does not resolve.

In a `(layer ...)` clause that makes KiCad reject the **entire** rule file, so every generated rule silently reverts to KiCad defaults. In the Pad to Silkscreen condition it fails with no message anywhere (#34).

## What changed

Three strings in `tools/generate_dru.py`, plus the eight generated files regenerated to match. No values changed — this is the layer name only.

`generate_dru.py --check` passes (generated output in sync with the TOML) and `lint_dru.py` passes. Grepped the branch afterwards: no `Silkscreen` spelling survives outside the two rule titles, which are prose.

## Why this branch and not main

Branched off this branch's head so it lands with the generator work rather than conflicting with it. The same fix for the hand-maintained files on `main` is in a separate PR.

Not a version regression — the layer names are identical in KiCad 7, 8, 9, 10 and master. Verified by running DRC on KiCad 9.0.6 and 10.0.5.

Refs #33
Refs #34
